### PR TITLE
The develop #27 had two issues.

### DIFF
--- a/jobs/JJOB_DA_3DVAR
+++ b/jobs/JJOB_DA_3DVAR
@@ -7,7 +7,7 @@
 
 module purge
 module use -a /contrib/da/modulefiles
-module load jedi
+module load jedi/jedim
 
 echo $RUNDIR
 cd $RUNDIR

--- a/jobs/JJOB_DA_PREP
+++ b/jobs/JJOB_DA_PREP
@@ -7,7 +7,7 @@
 
 module purge
 module use -a /contrib/da/modulefiles
-module load jedi
+module load jedi/jedim
 module load nco
 
 echo "SOCA_STATIC="$SOCA_STATIC

--- a/jobs/JJOB_GEN_ENSEMBLE
+++ b/jobs/JJOB_GEN_ENSEMBLE
@@ -7,7 +7,8 @@
 
 module purge
 module use -a /contrib/da/modulefiles
-module load jedi
+module load jedi/jedim
+module list
 
 echo $RUNDIR
 

--- a/jobs/JJOB_OBS_PREP
+++ b/jobs/JJOB_OBS_PREP
@@ -4,16 +4,16 @@ echo "J_JOB for OBS_PREP"
 echo $CDATE
 
 module purge
-#module use -a /contrib/da/modulefiles
-#module load jedi
+module use -a /contrib/da/modulefiles
+module load jedi/jedim
 #module load contrib
 #module load anaconda/latest
 
-module use -a /home/Stylianos.Flampouris/modulefiles
-module load anaconda/2019.08.07
-module list
+#module use -a /home/Stylianos.Flampouris/modulefiles
+#module load anaconda/2019.08.07
+#module list
 
-#module use -a /scratch3/NCEPDEV/marine/save/Todd.Spindler/modulefiles
-#module load ananconda3/1.0.0
+module use -a /scratch3/NCEPDEV/marine/save/Todd.Spindler/modulefiles
+module load ananconda3/1.0.0
 
 ${ROOT_GODAS_DIR}/scripts/main_obs_prep.sh

--- a/jobs/JJOB_PREP_3DVAR
+++ b/jobs/JJOB_PREP_3DVAR
@@ -7,7 +7,8 @@
 
 module purge
 module use -a /contrib/da/modulefiles
-module load jedi
+module load jed/jedim
+module listi
 
 echo $RUNDIR
 

--- a/jobs/JJOB_PREP_SOCA
+++ b/jobs/JJOB_PREP_SOCA
@@ -7,7 +7,8 @@
 
 module purge
 module use -a /contrib/da/modulefiles
-module load jedi
+module load jedi/jedim
+module list
 
 echo $RUNDIR
 

--- a/workflow/defaults/places.yaml
+++ b/workflow/defaults/places.yaml
@@ -6,8 +6,6 @@
 ##--------------------------------------------------------------------------------
 #
 default_places: &default_places
-<<<<<<< HEAD
-=======
 
   IODA_EXEC: !expand "{ROOT_GODAS_DIR}/build/bin"
 

--- a/workflow/platforms/hera.yaml
+++ b/workflow/platforms/hera.yaml
@@ -22,6 +22,12 @@ platform: !Platform
     {metasched.defvar(doc.schedvar.service_queue, doc.accounting.service_partition.service_queue)}
     {metasched.defvar(doc.schedvar.cpu_project, doc.accounting.cpu_project)}
 
+  # CHGRP_RSTPROD_COMMAND - this specifies the command to use to
+  # restrict access to NOAA "rstprod" data restriction class.
+  # This only used for observation processing, data assimilation, and
+  # data assimilation archiving, which are not in the public release.
+  CHGRP_RSTPROD_COMMAND: "chgrp rstprod"
+
   partitions:
     Evaluate: false
     default_shared: !calc doc.platform.partitions.hera


### PR DESCRIPTION
1. Indicators of conflict from merging (<<<<<HEAD ) at the places.yaml were merged to develop. Now they are removed. 
2. The CHGRP_RSTPROD_COMMAND is required and it was not included at the initial hera.yaml. The CHGRP_RSTPROD_COMMAND was added.

This PR addresses issue #28 .

Running the 3dvar branch **bugfix/issue28** fails to run the 3dvar, for the log file of the run see at /scratch2/NCEPDEV/marine/Stylianos.Flampouris/scrub/run_godas3dvar/workflowHera/log/2011100112/da_3dvar_run.log  
@guillaumevernieres could you check it? If I can help, let me know.