### PR TITLE
Checking if the ADT IODA obs exist and prepares the obs for ingestion

### DIFF
--- a/jobs/JJOB_OBS_PREP
+++ b/jobs/JJOB_OBS_PREP
@@ -13,7 +13,7 @@ module load jedi/jedim
 #module load anaconda/2019.08.07
 #module list
 
-module use -a /scratch3/NCEPDEV/marine/save/Todd.Spindler/modulefiles
-module load ananconda3/1.0.0
+#module use -a /scratch3/NCEPDEV/marine/save/Todd.Spindler/modulefiles
+#module load ananconda3/1.0.0
 
 ${ROOT_GODAS_DIR}/scripts/main_obs_prep.sh

--- a/scripts/SetupJoCostFunction.sh
+++ b/scripts/SetupJoCostFunction.sh
@@ -33,10 +33,10 @@ DATADIR=${RUNDIR}/Data
 
 mkdir -p ${DATADIR}
 
-obsdatabase=${ROTDIR}/${CDATE} 
+obsdatabase=${DATADIR}/${CDATE} 
 echo "obsdatabase="$obsdatabase
 # Add adt obs to Jo
-obsfile=$obsdatabase/ioda.adt.${DA_SLOT_LEN}h.nc 
+obsfile=$obsdatabase/ioda.adt.${DA_SLOT_LEN}h.nc
 if [ -f $obsfile ]; then
    echo "Adding ADT to Jo cost function"
    ln -sf ${obsfile} ${DATADIR}/adt.nc

--- a/scripts/adt_prep_obs.sh
+++ b/scripts/adt_prep_obs.sh
@@ -2,30 +2,41 @@
 
 cd $DCOM_ROOT
 
-OBSDCOM=$DCOM_ROOT/adt.nesdis/$PDY
+OBSDCOM=$DCOM_ROOT/adt.nesdis/$PDY              #FullPath of raw obs
+OUTFILE=ioda.adt.${DA_SLOT_LEN}h.nc             #Filename of the processed obs
+PREPROCobs=${IODA_ROOT}/${CDATE}/${OUTFILE}     #FullPath/Filename of preprocessed obs
+PROCobs=${ObsRunDir}/${OUTFILE}                 #FullPath/Filename of observations to be ingested
+
+#Check if the observations have been preprocessed.
+if [ -f "${PREPROCobs}" ]; then
+   echo
+   echo PreProcessed Observations are copied from "${PREPROCobs}" \
+        to ${PROCobs}
+   echo
+
+   cp -rf ${PREPROCobs} ${PROCobs}
+
+   return
+fi
+
+# Check if the raw observations exist and process.
 if [ -d "$OBSDCOM" ]; then
-   
-   OUTDIR=${ROTDIR}/${CDATE}
-   mkdir -p ${OUTDIR}
-   
+    
    cd $OBSDCOM
-   echo ADT Observations for $PDY exist at `pwd`
+   
+   echo ADT Observations for $PDY will be processed, obs directory: `pwd` 
    
    s="${IODA_EXEC}/rads_adt2ioda.py -i "
    for files in `ls *.nc`; do
       s+=" $OBSDCOM/${files} "
    done
    
-   s+=" -o ${OUTDIR}/ioda.adt.${DA_SLOT_LEN}h.nc -d ${CDATE}"
+   s+=" -o ${PROCobs} -d ${CDATE}"
    
-   set -x
    eval ${s}
-   set +x
+
 else
    
-   set -x
    echo There are no ADT observations for ${CDATE}  
-   set +x
 
 fi
- 

--- a/scripts/fnmoc_prep_obs.sh
+++ b/scripts/fnmoc_prep_obs.sh
@@ -1,37 +1,62 @@
 #!/bin/bash -l
 
-echo fnmoc_prep_obs.sh starts
-
-#set -x
-
 cd $DCOM_ROOT
 
-OBSDCOM=$DCOM_ROOT/insitu.fnmoc/$PDY
-   
-OUTDIR=${ROTDIR}/${CDATE}
-mkdir -p ${OUTDIR}
-   
-cd $OBSDCOM
-   
+OBSDCOM=$DCOM_ROOT/insitu.fnmoc/$PDY                           #FullPath of raw obs
+
+#Check if the observations have been preprocessed.
+
+prepobs_found=0
 for datafilename in profile ship trak
 do
-   datafile="$OBSDCOM/${PDY}00.${datafilename}"
-   
-   if [ -f "$datafile" ]; then
 
-      echo "$datafile" from FNMOC for $PDY exist at `pwd`
-
-      s="${IODA_EXEC}/godae_${datafilename}2ioda.py -i " 
-      s+=" ${datafile}"
-      s+=" -o ${OUTDIR}/ioda.${datafilename}.${DA_SLOT_LEN}h.nc -d ${CDATE}"
-      eval ${s}
+   OUTFILE=ioda.${datafilename}.${DA_SLOT_LEN}h.nc             #Filename of the processed obs
+   PREPROCobs=${IODA_ROOT}/${CDATE}/${OUTFILE}                 #FullPath/Filename of preprocessed obs
+   PROCobs=${ObsRunDir}/${OUTFILE}                             #FullPath/Filename of observations to be ingested
    
-   else
-      set -x
-      echo There are no $datafile observations for ${CDATE}  
-      set +x
+   if [ -f "${PREPROCobs}" ]; then
+      echo
+      echo PreProcessed Observations are copied from "${PREPROCobs}" \
+         to ${PROCobs}
+
+      cp -rf ${PREPROCobs} ${PROCobs}
+   
+      prepobs_found=1
    fi
 done
 
-echo fnmoc_prep_obs.sh ends
+if [ "$prepobs_found" = 1 ]; then
 
+   echo Preprocessed Observations were copied.
+   return
+
+fi
+# Check if the raw observations exist and process.
+
+for datafilename in profile ship trak
+do
+
+   OUTFILE=ioda.${datafilename}.${DA_SLOT_LEN}h.nc             #Filename of the processed obs
+   PREPROCobs=${IODA_ROOT}/${CDATE}/${OUTFILE}                 #FullPath/Filename of preprocessed obs
+   PROCobs=${ObsRunDir}/${OUTFILE}                             #FullPath/Filename of observations to be ingested
+   RawFileName="$OBSDCOM/${PDY}00.${datafilename}"
+   
+   if [ -f "$RawFileName" ]; then
+
+      echo "$RawFileName" from FNMOC for $PDY exist at `pwd`
+
+      s="${IODA_EXEC}/godae_${datafilename}2ioda.py -i " 
+      s+=" ${RawFileName}"
+      s+=" -o ${PROCobs} -d ${CDATE}"
+     
+      eval ${s}
+
+   else
+
+      echo There are no $RawFileName observations for ${CDATE}  
+
+   fi
+done
+#
+echo fnmoc_prep_obs.sh ends
+echo

--- a/scripts/main_obs_prep.sh
+++ b/scripts/main_obs_prep.sh
@@ -3,17 +3,21 @@ echo 'main_obs_prep.sh starts'
 echo ${ROOT_GODAS_DIR}
 echo CDATE is $CDATE
 
+ObsRunDir=$RUNDIR/Data/${CDATE}    #Path for observations to be ingested by DA
+mkdir -p ${ObsRunDir}
+
 source ${ROOT_GODAS_DIR}/scripts/adt_prep_obs.sh 
-source ${ROOT_GODAS_DIR}/scripts/fnmoc_prep_obs.sh
 
-ListOfSST="sst.windsat_l3u.ghrsst sst.amsr2_l3u.ghrsst \
-           sst.avhrr_l3u.nesdis sst.gmi_l3u.ghrsst \
-           sst.viirs_l3u.nesdis "
-
-for SSTsource in $ListOfSST;do
-   ${ROOT_GODAS_DIR}/scripts/sst_prep_obs.sh \
-                     -i ${SSTsource}
-done
+#source ${ROOT_GODAS_DIR}/scripts/fnmoc_prep_obs.sh
+#
+#ListOfSST="sst.windsat_l3u.ghrsst sst.amsr2_l3u.ghrsst \
+#           sst.avhrr_l3u.nesdis sst.gmi_l3u.ghrsst \
+#           sst.viirs_l3u.nesdis "
+#
+#for SSTsource in $ListOfSST;do
+#   ${ROOT_GODAS_DIR}/scripts/sst_prep_obs.sh \
+#                     -i ${SSTsource}
+#done
 
 
 # Testing the following

--- a/scripts/main_obs_prep.sh
+++ b/scripts/main_obs_prep.sh
@@ -8,7 +8,8 @@ mkdir -p ${ObsRunDir}
 
 source ${ROOT_GODAS_DIR}/scripts/adt_prep_obs.sh 
 
-#source ${ROOT_GODAS_DIR}/scripts/fnmoc_prep_obs.sh
+source ${ROOT_GODAS_DIR}/scripts/fnmoc_prep_obs.sh
+
 #
 #ListOfSST="sst.windsat_l3u.ghrsst sst.amsr2_l3u.ghrsst \
 #           sst.avhrr_l3u.nesdis sst.gmi_l3u.ghrsst \

--- a/workflow/config/base.yaml
+++ b/workflow/config/base.yaml
@@ -51,6 +51,7 @@ config_base:
 
     export SOCA_EXEC="{doc.places.SOCA_EXEC}"
     export DCOM_ROOT="{doc.places.DCOM_ROOT}"
+    export IODA_ROOT="{doc.places.IODA_ROOT}"
 
     ####################################################
     # DO NOT ADD MACHINE DEPENDENT STUFF BELOW THIS LINE

--- a/workflow/defaults/places.yaml
+++ b/workflow/defaults/places.yaml
@@ -22,10 +22,11 @@ default_places: &default_places
   EXPDIR :     !expand '{PROJECT_DIR}/{doc.names.experiment}'    # EXPDIR location
   LOG_DIR:     !expand "{EXPDIR}/log"                            # place to logs
   ROTDIR: !expand "{LONG_TERM_TEMP}/comrot/{doc.names.experiment}"   # Rotational directory
-  GODAS_RC:   "/scratch2/NCEPDEV/marine/marineda/"        # Root path for external data 
+  GODAS_RC:   "/scratch2/NCEPDEV/marine/marineda"        # Root path for external data 
   SOCA_EXEC:   !expand "{ROOT_GODAS_DIR}/build/bin"                # soca-bundle executable path
   SOCA_STATIC: !expand "{GODAS_RC}/soca-static/1440x1080x75"
-  DCOM_ROOT: !expand "{GODAS_RC}/ocean_observations/data"          # Observation root path
+  DCOM_ROOT: !expand "{GODAS_RC}/ocean_observations/data"          # Observation root path for raw obs
+  IODA_ROOT: !expand "{GODAS_RC}/ioda_observations"               # Processed observations
 
   MODEL_SCRATCH: "/scratch4/NCEPDEV/ocean/scrub/Guillaume.Vernieres/JEDI/mom6-cice5-fv3/test-initcice5/"
   SHORT_TERM_TEMP: !calc doc.platform.short_term_temp             # short term storage


### PR DESCRIPTION
This PR is for the ADT obs only, if it goes through, I will replicate it for the other observation types. Partially addresses #26 

1. Creates the $RUNDIR/Data
2. Checks if ADT obs in IODA format exist
- If yes,  copies them to  $RUNDIR/Data
- If no, process them and dumps them at  $RUNDIR/Data

Currently, python not working at hera computational nodes, so the processing will fail with a communication error 101. 

