### PR TITLE
Wrong resources assigned to var 

### DIFF
--- a/workflow/defaults/default_resources.yaml
+++ b/workflow/defaults/default_resources.yaml
@@ -11,7 +11,7 @@
 
 godas_resource_table:
       #              ranks   ppn wallclock            threads MB
-  r3dvar:        [ 624,   24, !timedelta "02:00:00", 12,  "3072" ]
+  r3dvar:        [ 200,   20, !timedelta "01:00:00", 12,  "3072" ]
   obs_prep:     [  12,   12, !timedelta "01:00:00", 1,   "3072"  ]
   da_prep:      [  72,   12, !timedelta "00:30:00", 1,   "3072" ]
 


### PR DESCRIPTION
closes #41 
- Bugfix to the last un-reviewed merge, please let's not do that again @JianKuang-NOAA , You need to wait for us to test and review, I know it is frustrating to wait, but that is how we will minimize the introduction of bugs.
- Scripts are hard-coded to 200 cores for the 3dvar, resources were asking for 32 nodes.