### PR TITLE
Remove the soca-bundle from the list of submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,4 @@
 [submodule "workflow/CROW"]
 	path = workflow/CROW
 	url = https://github.com/NOAA-EMC/CROW.git
-[submodule "src/soca-bundle"]
-	path = src/soca-bundle
-	url = https://github.com/JCSDA/soca-bundle.git
-	branch = release/stable-nightly
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 2. `cd godas`
 3. `git submodule update --init --recursive`
 
+# Clone the soca-bundle (bundle of repositories necessary to build soca)
+4. `cd ./src`
+5. `git clone --branch release/master_candidate https://github.com/JCSDA/soca-bundle.git`
+
 # Preparing the workflow
 1. `cd workflow` 
 2. Create/Edit `user.yaml` based on `user.yaml.default` \


### PR DESCRIPTION
closes #54 
closes #49 
Having the soca-bundle as a submodule creates issues when one of the branches of the bundled repositories are updated. The simple fix is to remove it from the list submodules, which is what this PR is implementing. I don't know if this is a long term solution, seems fine to me, but this is open for debate.
 