### PR TITLE
PR for cleaning the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ During this process, three directories will be created:
 
 # Preparing the workflow
 0. Create the directory that the workflow will be deployed:
-   `mkdir -p PROJECT_DIR` \
+   `mkdir -p PROJECT_DIR`
 1. `cd $CLONE_DIR/workflow` 
 2. Create/Edit `user.yaml` based on `user.yaml.default` \
    `cp user.yaml.default user.yaml` \
@@ -30,7 +30,7 @@ During this process, three directories will be created:
 Update the following fields in the `user.yaml` and save the file \
    `PROJECT_DIR: !error Please select a project directory.` \
    `FIX_SCRUB: False` \
-   `SCRUB: none # Please select a scrub space when FIX_SCRUB is True` \ 
+   `SCRUB: none # Please select a scrub space when FIX_SCRUB is True` \
    `user_email: none` \
    `cpu_project: !error Please select your cpu project` \
    `hpss_project: !error Please select your hpss project`
@@ -77,5 +77,7 @@ The workflow can interactively as shown at step 3. below or as cronjob.
 5. Repeat step 4 until all jobs are completed. 
 
 # Check the run and the results
-`cd ${RUNCDATE}` \
-Check the content of the directory.
+0. The log files of your experiment are at 
+`PROJECT_DIR/workflowtest001/log/`
+1. The the setup files and outputs of the experiment are at
+`${RUNCDATE}` 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,45 @@
+# Introduction
+The following five steps will guide you through the process of cloning, building and 
+running the GODAS workflow. 
+
+During this process, three directories will be created:
+- CLONE_DIR    : The directory where the system is cloned, user defined path
+
+- PROJECT_DIR  : The directory where the workflow is deployed, user defined path
+
+- RUNCDATE     : The directory where the system runs, optionally defined by the user.
+
+
 # Clone godas
-1. `git clone --recursive https://github.com/NOAA-EMC/godas.git godas`
-2. `cd godas`
+0. `set CLONE_DIR=PATH/OF/YOUR/CHOICE` 
+1. `git clone https://github.com/NOAA-EMC/godas.git $CLONE_DIR`
+2. `cd $CLONE_DIR`
 3. `git submodule update --init --recursive`
 
 # Clone the soca-bundle (bundle of repositories necessary to build soca)
-1. `cd ./src`
-2. `git clone --branch master https://github.com/JCSDA/soca-bundle.git`
+
+1. `git clone --branch master https://github.com/JCSDA/soca-bundle.git $CLONE_DIR/src`
 
 # Preparing the workflow
-1. `cd workflow` 
+0. Create the directory that the workflow will be deployed:
+   `mkdir -p PROJECT_DIR` \
+1. `cd $CLONE_DIR/workflow` 
 2. Create/Edit `user.yaml` based on `user.yaml.default` \
    `cp user.yaml.default user.yaml` \
    edit `user.yaml` \
 Update the following fields in the `user.yaml` and save the file \
    `PROJECT_DIR: !error Please select a project directory.` \
+   `FIX_SCRUB: False` \
+   `SCRUB: none # Please select a scrub space when FIX_SCRUB is True` \ 
    `user_email: none` \
    `cpu_project: !error Please select your cpu project` \
-   `hpss_project: !error Please select your hpss project` 
-3. `cd CROW`
+   `hpss_project: !error Please select your hpss project`
+
+If the variable FIX_SCRUB is true, the RUNCDATE directory will be created in the SCRUB.
+Otherwise the RUNCDATE is created automatically at stmpX directory of the user. 
+
+3. `cd $CLONE_DIR/workflow/CROW`
 4. Setup the workflow: \
-   Create the workflow directory (PROJECT_DIR) \
-   `mkdir -p PROJECT_DIR` \
    Select a name for the workflow path, e.g. workflowtest001 and a case, e.g. the 3dvar_only_exp: \
    `./setup_case.sh -p HERA -f ../cases/3dvar_only_exp.yaml workflowtest001`
    
@@ -29,20 +48,17 @@ Update the following fields in the `user.yaml` and save the file \
 5. Read output and run suggested command. Should be similar to: \
    `./make_rocoto_xml_for.sh PROJECT_DIR/workflowtest001` 
 # Building the soca-bundle 
-
-0. `cd [...]/godas/src/soca-bundle`
+0. Create the build directory for SOCA
+   `mkdir -p $CLONE_DIR/build` \
+   `cd $CLONE_DIR/build`
 1. Load the JEDI modules \
    `module purge` \
    `module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles` \
    `module load jedi-intel-17.0.5.239`
-2. Create out of source build directory \
-   `cd [...]/godas` \
-   `mkdir build` \
-   `cd build`
-3. Clone all the necessary repositories to build soca \
+2. Clone all the necessary repositories to build soca \
    `ecbuild --build=release -DMPIEXEC=$MPIEXEC -DMPIEXEC_EXECUTABLE=$MPIEXEC -DBUILD_ECKIT=YES ../src/soca-bundle`
-4. `make -j12`
-5. Unit test the build \
+3. `make -j12`
+4. Unit test the build \
    `salloc --ntasks 12 --qos=debug --time=00:30:00 --account=marine-cpu` \
    `ctest`
  
@@ -60,3 +76,6 @@ The workflow can interactively as shown at step 3. below or as cronjob.
    `rocotorun -w workflow.xml -d workflow.db & rocotostat -v 10 -w workflow.xml -d workflow.db`
 5. Repeat step 4 until all jobs are completed. 
 
+# Check the run and the results
+`cd ${RUNCDATE}` \
+Check the content of the directory.


### PR DESCRIPTION
The following parts of the README were cleaned:
1. Remove the recursive cloning, which potentially creates issues and 
2. Clarify which directories are needed to deploy and run the system. Almost everybody at the tutorial asked the same question about the different paths. 

Before approving please use the updated instruction to clone, install and run the system

Closes #62 and addresses partially the #60 