### PR TITLE
Removing use of scratch4

### DIFF
--- a/jobs/JJOB_DA_PREP
+++ b/jobs/JJOB_DA_PREP
@@ -17,8 +17,7 @@ mkdir -p $RUNCDATE
 cd $RUNCDATE
 
 # TODO: Hard-coded stuff that needs to be moved/changed
-export MODEL_SCRATCH=/scratch4/NCEPDEV/ocean/scrub/Guillaume.Vernieres/JEDI/mom6-cice5-fv3/test-initcice5/
-
+export MODEL_SCRATCH=/scratch2/NCEPDEV/ocean/Guillaume.Vernieres/mom6-cice5-fv3/test-initcice5
 cdate2window_begin(){ echo ${1:0:4}-${1:4:2}-${1:6:2}T00:00:00Z; }  # TODO: Hardcoded for 24hr DA window,
 cdate2bkg_date(){ echo ${1:0:4}-${1:4:2}-${1:6:2}T12:00:00Z; }      # make generic.
 


### PR DESCRIPTION
Thanks to @flampouris for finding the bug. We were still pointing to the old file system from Theia for the model's initial conditions.