### PR TITLE
Add EnVAR functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Otherwise the RUNCDATE is created automatically at stmpX directory of the user.
  5. Change the soca-config branch \
     The yaml files that configure the DA experiments live inside of the soca-config repository. For example, to checkout the feature branch for the 3DVAR: \
    `cd $CLONE_DIR/soca-bundle/soca-config` \
-   `git checkout feature/emc-3dvar` \
+   `git checkout develop` \
     or alternatively, checkout your own branch or the branch you need to test with.
 # Running the workflow
 Assumption all the subsystems have been compiled.

--- a/jobs/JJOB_DA_3DENVAR
+++ b/jobs/JJOB_DA_3DENVAR
@@ -1,0 +1,89 @@
+#!/bin/bash -l
+set -e
+
+cat <<EOF
+#================================================================================
+#================================================================================
+# JJOB_DA_3DENVAR
+#   Run SOCA 3DVAR, checkpoint, forecast
+#================================================================================
+#================================================================================
+EOF
+module purge
+module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles/
+module load jedi-intel-17.0.5.239
+
+cd $RUNCDATE
+
+cat <<EOF
+#============================================
+# Link ensemble members for ENVAR
+#============================================
+EOF
+# link files here
+
+cat <<EOF
+#============================================
+# Run SOCA 3DENVAR
+#============================================
+EOF
+export OOPS_TRACE=0
+srun -n $NPE ${SOCA_EXEC}/soca_3dvar.x ./yaml/3dhybenvar.yml
+
+cat <<EOF
+#============================================
+# Checkpoint SOCA 3DENVAR analysis
+#============================================
+EOF
+if   [ ! -d RESTART ]; then mkdir -p RESTART; fi
+srun -n $NPE ${SOCA_EXEC}/soca_checkpoint_model.x ./yaml/checkpointmodel.yml
+
+cat <<EOF
+#========================================================
+# Prepare restarting deterministic forecast from analysis
+#========================================================
+EOF
+if [ -d ANA ]; then rm -Rf ANA; fi
+if [ ! -d ANA ]; then mkdir -p ANA; fi
+ln -s $PWD/INPUT_MOM6/* ./ANA/
+# Unlink old restarts
+rm -f ./ANA/MOM.*.nc
+rm -f $PWD/ANA/cice_bkg.nc
+# Get MOM's restart
+mv -f RESTART/MOM.*.nc ./ANA/  # Because checkpoint dumps analysis in RESTART
+ln -s $PWD/Data/cic.socagodas.an.*.nc ./ANA/cice_bkg.nc
+
+cat <<EOF
+#============================================
+# Run mom6 only deterministic forecast
+#============================================
+EOF
+if   [ ! -d RESTART ]; then mkdir -p RESTART; fi
+srun -n $NPE ${SOCA_EXEC}/soca_forecast.x ./yaml/forecast.yml
+
+cat <<EOF
+#============================================
+# Move ocean and ice restarts to place holder for next cycle
+#============================================
+EOF
+mv -f ./RESTART ../NEXT_IC
+mv -f ./ANA/cice_bkg.nc ../NEXT_IC/cice_bkg.nc
+
+cat <<EOF
+#============================================
+# Run mom6 only genpert forecast
+#============================================
+EOF
+if   [ ! -d RESTART ]; then mkdir -p RESTART; fi
+srun -n $NPE ${SOCA_EXEC}/soca_enspert.x ./yaml/genenspert4envar.yml
+
+cat <<EOF
+#============================================
+# Move ensemble forecast to place holder for next cycle
+#============================================
+EOF
+if [ ! -d ../NEXT_ENS ]; then mkdir -p ../NEXT_ENS; fi
+for (( mbr=1; mbr<=${NO_ENS_MBR} ; mbr++ )); do
+    mv -f ./Data/ocn.pert.ens.${mbr}.*.P1D.nc ../NEXT_ENS/ocn.pert.ens.${mbr}.nc
+    mv -f ./Data/cic.pert.ens.${mbr}.*.P1D.nc ../NEXT_ENS/cic.pert.ens.${mbr}.nc
+done

--- a/jobs/JJOB_DA_3DVAR
+++ b/jobs/JJOB_DA_3DVAR
@@ -36,14 +36,15 @@ cat <<EOF
 # Prepare restarting from analysis
 #============================================
 EOF
+if [ -d ANA ]; then rm -Rf ANA; fi
 if [ ! -d ANA ]; then mkdir -p ANA; fi
 ln -s $PWD/INPUT_MOM6/* ./ANA/
 # Unlink old restarts
-rm ./ANA/MOM.*.nc
-rm $PWD/ANA/cice_bkg.nc 
+rm -f ./ANA/MOM.*.nc
+rm -f $PWD/ANA/cice_bkg.nc
 # Get MOM's restart
-mv RESTART/MOM.*.nc ./ANA/  # Because checkpoint dumps analysis in RESTART
-ln -s $PWD/Data/cic.3dvargodas.an.*.nc ./ANA/cice_bkg.nc
+mv -f RESTART/MOM.*.nc ./ANA/  # Because checkpoint dumps analysis in RESTART
+ln -s $PWD/Data/cic.socagodas.an.*.nc ./ANA/cice_bkg.nc
 
 cat <<EOF
 #============================================

--- a/jobs/JJOB_DA_PREP
+++ b/jobs/JJOB_DA_PREP
@@ -69,16 +69,22 @@ echo "window_length="$window_length
 echo "bkg_date="$bkg_date
 echo "MODEL_SCRATCH="$MODEL_SCRATCH
 
-## Prep yaml for bump initialization 
-#-----------------------------------
+## Prep yaml for bump correlation initialization 
+#-----------------------------------------------
 ${ROOT_GODAS_DIR}/scripts/prep_BKG_DATE_yaml.sh    \
-      -i $RUNCDATE/yaml/static_SocaError_init.yml    \
+      -i $RUNCDATE/yaml/static_SocaError_init.yml  \
+      -d ${bkg_date}
+
+## Prep yaml for bump localization initialization 
+#------------------------------------------------
+${ROOT_GODAS_DIR}/scripts/prep_BKG_DATE_yaml.sh    \
+      -i $RUNCDATE/yaml/parameters_bump_loc.yml    \
       -d ${bkg_date}
 
 ## Prep yaml for checkpointing 3DVAR analysis
 #--------------------------------------------
 ${ROOT_GODAS_DIR}/scripts/prep_BKG_DATE_yaml.sh    \
-      -i $RUNCDATE/yaml/checkpointmodel.yml          \
+      -i $RUNCDATE/yaml/checkpointmodel.yml        \
       -d ${bkg_date}
 
 ## Prep yaml for running mom6 only forecast
@@ -98,11 +104,45 @@ ${ROOT_GODAS_DIR}/scripts/replace_KWRD_yaml.sh     \
       -k NO_ENS_MBR                                \
       -v ${NO_ENS_MBR}
 
+## Prep yaml for the soca_enspert for envar 
+#--------------------------------------------------------------
+${ROOT_GODAS_DIR}/scripts/prep_BKG_DATE_yaml.sh    \
+      -i $RUNCDATE/yaml/genenspert4envar.yml       \
+      -d ${bkg_date}
+
+${ROOT_GODAS_DIR}/scripts/replace_KWRD_yaml.sh     \
+      -i $RUNCDATE/yaml/genenspert4envar.yml       \
+      -k NO_ENS_MBR                                \
+      -v ${NO_ENS_MBR}
+
+${ROOT_GODAS_DIR}/scripts/replace_KWRD_yaml.sh     \
+      -i $RUNCDATE/yaml/genenspert4envar.yml       \
+      -k WINDOW_LENGTH                             \
+      -v ${window_length}
+
 # Prep yaml for 3dvar 
-#----------------------------------
+#-----------------------------
 ${ROOT_GODAS_DIR}/scripts/prep_3dvar_yaml.sh       \
-      -i $RUNCDATE/yaml/3dvar_godas.yml              \
+      -i $RUNCDATE/yaml/3dvar_godas.yml            \
       -d $RUNCDATE
+
+# Prep yaml for 3denvar 
+#----------------------------------
+${ROOT_GODAS_DIR}/scripts/prep_3denvar_yaml.sh    \
+      -i $RUNCDATE/yaml/3dhybenvar.yml            \
+      -m $RUNCDATE/yaml/envar_member.yml          \
+      -d $RUNCDATE                                \
+      -n ${NO_ENS_MBR}
+
+# Prep yaml for ensemble variance
+#------------------------------------------------
+# TODO: Not clean, using prep_3denvar_yaml.sh to create ens. variance yaml
+${ROOT_GODAS_DIR}/scripts/prep_3denvar_yaml.sh    \
+      -i $RUNCDATE/yaml/ensvariance.yml            \
+      -m $RUNCDATE/yaml/ensvariance_member.yml          \
+      -d $RUNCDATE                                \
+      -n ${NO_ENS_MBR}
+
 
 #----------------------------------
 if [ $case = 'en' ]; then 
@@ -113,7 +153,7 @@ if [ $case = 'en' ]; then
    
       ${ROOT_GODAS_DIR}/scripts/prep_hofx3d_yaml.sh   \
          -i ${yaml_tmp}                               \
-         -d ${RUNCDATE}                                 \
+         -d ${RUNCDATE}                               \
          -n ${mbr}
       
       jjob_tmp=${ROOT_GODAS_DIR}/jobs/JJOB_PREP_LETKF${mbr}
@@ -132,6 +172,11 @@ if [ -d ../NEXT_IC ]; then
     # Get IC from previous cycle
     cp ../NEXT_IC/cice_bkg.nc $RUNCDATE/INPUT_MOM6/cice_bkg.nc  
     cp ../NEXT_IC/MOM*.nc $RUNCDATE/INPUT_MOM6/
+
+    if [ -d ../NEXT_ENS ]; then
+	mv ../NEXT_ENS/* $RUNCDATE/Data/
+    fi
+    rm -rf ../NEXT_ENS
     rm -rf ../NEXT_IC
     exit 0
 fi
@@ -141,6 +186,10 @@ fi
 # Ocean bkg files
 #----------------
 ln -sf $MODEL_SCRATCH/INPUT/MOM.res*.nc $RUNCDATE/INPUT_MOM6/
+
+# Initial Ocean and Ice perturbations
+#---------------------------------------------------
+ln -sf $MODEL_SCRATCH/ens/*.nc $RUNCDATE/Data/
 
 # Sea-ice bkg files
 #------------------

--- a/jobs/JJOB_PREP_SOCA
+++ b/jobs/JJOB_PREP_SOCA
@@ -31,14 +31,14 @@ else
     srun --nodes=1 --ntasks=12 ${SOCA_EXEC}/soca_gridgen.x ./yaml/gridgen.yml
 fi
 
-# Create BUMP convolution operator
+# Create BUMP convolution operator (computes convolution weights)
 echo
 echo 'Initializing BUMP.'
 echo
 mkdir -p bump
 srun -n $NPE ${SOCA_EXEC}/soca_staticbinit.x ./yaml/static_SocaError_init.yml
 
-# Generate BUMP localization
+# Initialize BUMP localization (computes localization weights)
 if [ ${NO_ENS_MBR}>1 ]; then
     echo
     echo 'Initializing BUMP Localization.'

--- a/jobs/JJOB_PREP_SOCA
+++ b/jobs/JJOB_PREP_SOCA
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -e
 
-#================================================================================
-#================================================================================
-
-
 cat <<EOF
 #================================================================================
 #================================================================================
@@ -41,3 +37,11 @@ echo 'Initializing BUMP.'
 echo
 mkdir -p bump
 srun -n $NPE ${SOCA_EXEC}/soca_staticbinit.x ./yaml/static_SocaError_init.yml
+
+# Generate BUMP localization
+if [ ${NO_ENS_MBR}>1 ]; then
+    echo
+    echo 'Initializing BUMP Localization.'
+    echo
+    srun -n $NPE ${SOCA_EXEC}/soca_parameters.x ./yaml/parameters_bump_loc.yml
+fi

--- a/scripts/prep_3denvar_yaml.sh
+++ b/scripts/prep_3denvar_yaml.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -l
 #
-# * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # 
-#                       Unix Script Documentation 
-# 
+# * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * #
+#                       Unix Script Documentation
+#
 # Script Name        :
 #
 # Script Description :
@@ -13,24 +13,35 @@
 #
 # History Log        :
 #
-# * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # 
+# * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * # * #
 # set -x
 
 echo '#=================================================================#'
-echo '#                    prep_3dvar_yaml.sh starts                    #'
+echo '#                    prep_3denvar_yaml.sh starts                  #'
 echo '#                                                                 #'
 
-while getopts "i:d:n:" opt; do
+while getopts "i:m:d:n:" opt; do
    case $opt in
       i) yamlfile=("$OPTARG");;
+      m) yamlmember=("$OPTARG");;
       d) RUNDIR=("$OPTARG");;
+      n) Ne=("$OPTARG");;
    esac
 done
 shift $((OPTIND -1))
 
 cd ${RUNDIR}
 
-## Set date for 3DVAR
+echo $membertemplate
+for (( mbr=1; mbr<=${Ne} ; mbr++ )); do
+    echo "I am member "$mbr
+    cp $yamlmember tmpl.txt
+    sed -i "s/ENS_NUM/${mbr}/g" tmpl.txt
+    sed -e '/ENSEMBLE_MEMBERS/ {' -e 'r tmpl.txt' -e 'd' -e '}' -i ${yamlfile}
+    rm tmpl.txt
+done
+
+## Set date
 sed -i "s/WINDOW_BEGIN/${window_begin}/g" ${yamlfile}
 sed -i "s/WINDOW_LENGTH/${window_length}/g" ${yamlfile}
 sed -i "s/BKG_DATE/${bkg_date}/g" ${yamlfile}
@@ -43,6 +54,5 @@ ${ROOT_GODAS_DIR}/scripts/SetupJoCostFunction.sh \
       -d $RUNDIR
 
 echo '#                                                                 #'
-echo '#                      prep_3dvar_yaml.sh ends                    #'
+echo '#                      prep_3denvar_yaml.sh ends                  #'
 echo '#=================================================================#'
- 

--- a/scripts/prep_3denvar_yaml.sh
+++ b/scripts/prep_3denvar_yaml.sh
@@ -34,7 +34,6 @@ cd ${RUNDIR}
 
 echo $membertemplate
 for (( mbr=1; mbr<=${Ne} ; mbr++ )); do
-    echo "I am member "$mbr
     cp $yamlmember tmpl.txt
     sed -i "s/ENS_NUM/${mbr}/g" tmpl.txt
     sed -e '/ENSEMBLE_MEMBERS/ {' -e 'r tmpl.txt' -e 'd' -e '}' -i ${yamlfile}

--- a/scripts/prep_3dvar_yaml.sh
+++ b/scripts/prep_3dvar_yaml.sh
@@ -20,7 +20,7 @@ echo '#=================================================================#'
 echo '#                    prep_3dvar_yaml.sh starts                    #'
 echo '#                                                                 #'
 
-while getopts "i:d:n:" opt; do
+while getopts "i:d:" opt; do
    case $opt in
       i) yamlfile=("$OPTARG");;
       d) RUNDIR=("$OPTARG");;

--- a/scripts/prep_ensvariance_yaml.sh
+++ b/scripts/prep_ensvariance_yaml.sh
@@ -34,7 +34,6 @@ cd ${RUNDIR}
 
 echo $membertemplate
 for (( mbr=1; mbr<=${Ne} ; mbr++ )); do       
-    echo "I am member "$mbr
     cp $yamlmember tmpl.txt
     sed -i "s/ENS_NUM/${mbr}/g" tmpl.txt
     sed -e '/ENSEMBLE_MEMBERS/ {' -e 'r tmpl.txt' -e 'd' -e '}' -i ${yamlfile}

--- a/scripts/prep_ensvariance_yaml.sh
+++ b/scripts/prep_ensvariance_yaml.sh
@@ -17,20 +17,31 @@
 # set -x
 
 echo '#=================================================================#'
-echo '#                    prep_3dvar_yaml.sh starts                    #'
+echo '#                    prep_3denvar_yaml.sh starts                  #'
 echo '#                                                                 #'
 
-while getopts "i:d:n:" opt; do
+while getopts "i:m:d:n:" opt; do
    case $opt in
       i) yamlfile=("$OPTARG");;
+      m) yamlmember=("$OPTARG");;
       d) RUNDIR=("$OPTARG");;
+      n) Ne=("$OPTARG");;
    esac
 done
 shift $((OPTIND -1))
 
 cd ${RUNDIR}
 
-## Set date for 3DVAR
+echo $membertemplate
+for (( mbr=1; mbr<=${Ne} ; mbr++ )); do       
+    echo "I am member "$mbr
+    cp $yamlmember tmpl.txt
+    sed -i "s/ENS_NUM/${mbr}/g" tmpl.txt
+    sed -e '/ENSEMBLE_MEMBERS/ {' -e 'r tmpl.txt' -e 'd' -e '}' -i ${yamlfile}
+    rm tmpl.txt
+done
+
+## Set date
 sed -i "s/WINDOW_BEGIN/${window_begin}/g" ${yamlfile}
 sed -i "s/WINDOW_LENGTH/${window_length}/g" ${yamlfile}
 sed -i "s/BKG_DATE/${bkg_date}/g" ${yamlfile}
@@ -43,6 +54,5 @@ ${ROOT_GODAS_DIR}/scripts/SetupJoCostFunction.sh \
       -d $RUNDIR
 
 echo '#                                                                 #'
-echo '#                      prep_3dvar_yaml.sh ends                    #'
+echo '#                      prep_3denvar_yaml.sh ends                  #'
 echo '#=================================================================#'
- 

--- a/workflow/cases/3denvar.yaml
+++ b/workflow/cases/3denvar.yaml
@@ -1,0 +1,8 @@
+case:
+  settings:
+    SDATE: 2011-10-01t12:00:00
+    EDATE: 2011-10-02t12:00:00
+    godas_cyc: 1 # selection of godas cycle: 1(default)- 24h; 2 - 12h; 4 - 6h
+
+  places:
+    workflow_file: layout/3denvar_only.yaml

--- a/workflow/defaults/default_resources.yaml
+++ b/workflow/defaults/default_resources.yaml
@@ -11,7 +11,7 @@
 
 godas_resource_table:
 #                ranks  ppn  wallclock              threads MB
-  r3dvar:       [  100,   20, !timedelta "01:00:00", 12,  "3072" ]
+  r3dvar:       [  80,   20, !timedelta "01:00:00", 12,  "3072" ]
   obs_prep:     [  12,   12, !timedelta "01:00:00", 1,   "3072"  ]
   da_prep:      [  1,   1, !timedelta "00:30:00", 1,   "3072" ]
 

--- a/workflow/defaults/default_resources.yaml
+++ b/workflow/defaults/default_resources.yaml
@@ -11,7 +11,8 @@
 
 godas_resource_table:
 #                ranks  ppn  wallclock              threads MB
-  r3dvar:       [  80,   20, !timedelta "01:00:00", 12,  "3072" ]
+  r3dvar:       [  20,   20, !timedelta "01:00:00", 12,  "3072" ]
+  r3denvar:     [  80,   20, !timedelta "01:00:00", 12,  "3072" ]
   obs_prep:     [  12,   12, !timedelta "01:00:00", 1,   "3072"  ]
   da_prep:      [  1,   1, !timedelta "00:30:00", 1,   "3072" ]
 
@@ -39,3 +40,9 @@ default_resources: &default_resources
       mpi_ranks: !calc doc.godas_resource_table.r3dvar[0]
       walltime: !calc doc.godas_resource_table.r3dvar[2]
       max_ppn: !calc doc.godas_resource_table.r3dvar[1]
+
+  run_3denvar: !JobRequest
+    - batch_memory: !calc doc.godas_resource_table.r3denvar[4]
+      mpi_ranks: !calc doc.godas_resource_table.r3denvar[0]
+      walltime: !calc doc.godas_resource_table.r3denvar[2]
+      max_ppn: !calc doc.godas_resource_table.r3denvar[1]

--- a/workflow/defaults/places.yaml
+++ b/workflow/defaults/places.yaml
@@ -14,7 +14,7 @@ default_places: &default_places
   DA_SLOT_LEN: 24
 # To be removed as soon as there is an ensemble yaml file
 # Number of ensemble members
-  NO_ENS_MBR: 40
+  NO_ENS_MBR: 5
 # Model resolution
   NI: 360 #1440
   NJ: 210 #1080
@@ -22,7 +22,7 @@ default_places: &default_places
 # Ice model file format
   ICE_FMT: fms # notfms
 # Number of procs for DA
-  NPE: 80
+  NPE: 20
 
   PROJECT_DIR: !error Please select a project directory.         # place to generate EXPDIR
   ROOT_GODAS_DIR: !calc ( tools.realpath(tools.abspath("../../")) )  # godas package path

--- a/workflow/defaults/places.yaml
+++ b/workflow/defaults/places.yaml
@@ -1,7 +1,7 @@
 # This file sets default values for data and executable locations.
 # See the schema/places.yaml for details.
 #--------------------------------------------------------------------------------
-## Fixed directories. 
+## Fixed directories.
 ##
 ##--------------------------------------------------------------------------------
 #
@@ -14,15 +14,15 @@ default_places: &default_places
   DA_SLOT_LEN: 24
 # To be removed as soon as there is an ensemble yaml file
 # Number of ensemble members
-  NO_ENS_MBR: 5
+  NO_ENS_MBR: 40
 # Model resolution
-  NI: 360 #1440   
+  NI: 360 #1440
   NJ: 210 #1080
   NK: 75
 # Ice model file format
   ICE_FMT: fms # notfms
 # Number of procs for DA
-  NPE: 100
+  NPE: 80
 
   PROJECT_DIR: !error Please select a project directory.         # place to generate EXPDIR
   ROOT_GODAS_DIR: !calc ( tools.realpath(tools.abspath("../../")) )  # godas package path
@@ -30,7 +30,7 @@ default_places: &default_places
   EXPDIR :     !expand '{PROJECT_DIR}/{doc.names.experiment}'    # EXPDIR location
   LOG_DIR:     !expand "{EXPDIR}/log"                            # place to logs
   ROTDIR: !expand "{LONG_TERM_TEMP}/comrot/{doc.names.experiment}"   # Rotational directory
-  GODAS_RC:   "/scratch2/NCEPDEV/marine/marineda"        # Root path for external data 
+  GODAS_RC:   "/scratch2/NCEPDEV/marine/marineda"        # Root path for external data
   SOCA_EXEC:   !expand "{ROOT_GODAS_DIR}/build/bin"                # soca-bundle executable path
   SOCA_STATIC: !expand "{GODAS_RC}/soca-static/{NI}x{NJ}x{NK}"
   SOCA_CONFIG:   !expand "{ROOT_GODAS_DIR}/src/soca-bundle/soca-config/emc"             # soca-config path
@@ -40,4 +40,4 @@ default_places: &default_places
   MODEL_SCRATCH: "/scratch2/NCEPDEV/ocean/Guillaume.Vernieres/mom6-cice5-fv3/{NI}x{NJ}x{NK}"
   SHORT_TERM_TEMP: !calc doc.platform.short_term_temp             # short term storage
   LONG_TERM_TEMP:  !calc doc.platform.long_term_temp              # long term storage
-  RUNDIR: !expand "{LONG_TERM_TEMP}/{tools.env('USER')}/rundir/{doc.names.experiment}" # RUN directory  
+  RUNDIR: !expand "{LONG_TERM_TEMP}/{tools.env('USER')}/rundir/{doc.names.experiment}" # RUN directory

--- a/workflow/layout/3denvar_only.yaml
+++ b/workflow/layout/3denvar_only.yaml
@@ -18,14 +18,14 @@ suite: !Cycle
       da_prep_soca: !Task
         <<: *shared_task_template
         Trigger: !Depend  da_prep
-        resources: !calc partition.resources.run_3dvar
+        resources: !calc partition.resources.run_3denvar
         config: [ base ]
         J_JOB: JJOB_PREP_SOCA
 
       da_3denvar_run: !Task
         <<: *shared_task_template
         Trigger: !Depend  ( da_prep_soca & obs_prep )
-        resources: !calc partition.resources.run_3dvar
+        resources: !calc partition.resources.run_3denvar
         config: [ base ]
         J_JOB: JJOB_DA_3DENVAR
 

--- a/workflow/layout/3denvar_only.yaml
+++ b/workflow/layout/3denvar_only.yaml
@@ -1,0 +1,60 @@
+suite: !Cycle
+      <<: *suite_defaults
+
+      obs_prep: !Task
+        <<: *shared_task_template
+        Trigger: !Depend  ( ~ suite.has_cycle('-24:00:00') | fcst_run.at('-24:00:00'))
+        resources: !calc partition.resources.run_obs_prep
+        config: [ base ]
+        J_JOB: JJOB_OBS_PREP
+
+      da_prep: !Task
+        <<: *shared_task_template
+        Trigger: !Depend  obs_prep
+        resources: !calc partition.resources.run_da_prep
+        config: [ base ]
+        J_JOB: JJOB_DA_PREP
+
+      da_prep_soca: !Task
+        <<: *shared_task_template
+        Trigger: !Depend  da_prep
+        resources: !calc partition.resources.run_3dvar
+        config: [ base ]
+        J_JOB: JJOB_PREP_SOCA
+
+      da_3denvar_run: !Task
+        <<: *shared_task_template
+        Trigger: !Depend  ( da_prep_soca & obs_prep )
+        resources: !calc partition.resources.run_3dvar
+        config: [ base ]
+        J_JOB: JJOB_DA_3DENVAR
+
+      fcst_prep: !Task
+        <<: *shared_task_template
+        Trigger: !Depend da_3denvar_run
+        resources: !calc partition.resources.run_nothing
+        config: [ base ]
+        J_JOB: JJOB_FCST_PREP
+
+      fcst_run: !Task
+        <<: *exclusive_task_template
+        Trigger: !Depend  fcst_prep
+        resources: !calc partition.resources.run_nothing
+        config: [ base ]
+        J_JOB: JJOB_FORECAST
+
+      post: !Task
+        <<: *shared_task_template
+        Trigger: !Depend  fcst_run
+        resources: !calc partition.resources.run_nothing
+        rocoto_command: "echo post"
+        config: [ base ]
+        J_JOB: JJOB_POST
+
+      final: !Task
+        <<: *service_task_template
+        Disable: !calc not metasched.type=="rocoto"
+        resources: !calc partition.resources.run_nothing
+        rocoto_command: "echo final"
+        rocoto_command: /bin/true
+        RUN: gfs # useless but required


### PR DESCRIPTION
This work implements a functional EnVAR, perturbations are generated at every cycle using the "genpert.x" application instead of the letkf (next pr).
To run the test, it needs the branch feature/emc-envar of soca-config.

See issue #99 for more details.
closes #99 

