### PR TITLE
Switch to Intel 19 and soca-bundle release/stable-nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ During this process, three directories will be created:
 
 # Clone the soca-bundle (bundle of repositories necessary to build soca)
 
-1. `git clone --branch master https://github.com/JCSDA/soca-bundle.git $CLONE_DIR/src`
-
+1. `git clone --branch release/stable-nightly https://github.com/JCSDA/soca-bundle.git $CLONE_DIR/src`
+ 
 # Preparing the workflow
 0. Create the directory that the workflow will be deployed:
    `mkdir -p PROJECT_DIR`
@@ -41,7 +41,7 @@ Otherwise the RUNCDATE is created automatically at stmpX directory of the user.
 3. `cd $CLONE_DIR/workflow/CROW`
 4. Setup the workflow: \
    Select a name for the workflow path, e.g. workflowtest001 and a case, e.g. the 3dvar: \
-   `./setup_case.sh -p HERA -f ../cases/3dvar.yaml workflowtest001`
+   `./setup_case.sh -p HERA ../cases/3dvar.yaml workflowtest001`
  
    This will setup the workflow in `workflowtest001` for the 3DVAR case on Hera.
  
@@ -59,8 +59,8 @@ Otherwise the RUNCDATE is created automatically at stmpX directory of the user.
    `cd $CLONE_DIR/build`
 1. Load the JEDI modules \
    `module purge` \
-   `module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles` \
-   `module load jedi-intel-17.0.5.239`
+   `module use -a /scratch1/NCEPDEV/stmp4/Daniel.Holdaway/opt/modulefiles` \
+   `module load apps/jedi/intel-19.0.5.281`
 2. Clone all the necessary repositories to build soca \
    `ecbuild --build=release -DMPIEXEC=$MPIEXEC -DMPIEXEC_EXECUTABLE=$MPIEXEC -DBUILD_ECKIT=YES ../src/soca-bundle`
 3. `make -j12`
@@ -73,7 +73,7 @@ Otherwise the RUNCDATE is created automatically at stmpX directory of the user.
    `git checkout develop` \
     or alternatively, checkout your own branch or the branch you need to test with.
 # Running the workflow
-Assumption all the subsystems have been compiled.
+Assumption: All the subsystems have been compiled.
 The workflow can interactively as shown at step 3. below or as cronjob.
 
 1. Go into the test directory \

--- a/jobs/JJOB_DA_3DENVAR
+++ b/jobs/JJOB_DA_3DENVAR
@@ -10,8 +10,8 @@ cat <<EOF
 #================================================================================
 EOF
 module purge
-module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles/
-module load jedi-intel-17.0.5.239
+module use -a /scratch1/NCEPDEV/stmp4/Daniel.Holdaway/opt/modulefiles
+module load apps/jedi/intel-19.0.5.281
 
 cd $RUNCDATE
 

--- a/jobs/JJOB_DA_3DVAR
+++ b/jobs/JJOB_DA_3DVAR
@@ -10,8 +10,8 @@ cat <<EOF
 #================================================================================
 EOF
 module purge
-module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles/
-module load jedi-intel-17.0.5.239
+module use -a /scratch1/NCEPDEV/stmp4/Daniel.Holdaway/opt/modulefiles
+module load apps/jedi/intel-19.0.5.281
 
 cd $RUNCDATE
 

--- a/jobs/JJOB_DA_PREP
+++ b/jobs/JJOB_DA_PREP
@@ -11,8 +11,8 @@ cat <<EOF
 EOF
 
 module purge
-module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles/
-module load jedi-intel-17.0.5.239
+module use -a /scratch1/NCEPDEV/stmp4/Daniel.Holdaway/opt/modulefiles
+module load apps/jedi/intel-19.0.5.281
 module load nco
 
 echo  

--- a/jobs/JJOB_GEN_ENSEMBLE
+++ b/jobs/JJOB_GEN_ENSEMBLE
@@ -6,8 +6,8 @@
 # Generate the ensemble
 
 module purge
-module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles/
-module load jedi-intel-17.0.5.239
+module use -a /scratch1/NCEPDEV/stmp4/Daniel.Holdaway/opt/modulefiles
+module load apps/jedi/intel-19.0.5.281
 
 echo $RUNCDATE
 

--- a/jobs/JJOB_OBS_PREP
+++ b/jobs/JJOB_OBS_PREP
@@ -4,8 +4,8 @@ echo "J_JOB for OBS_PREP"
 echo $CDATE
 
 module purge
-module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles/
-module load jedi-intel-17.0.5.239
+module use -a /scratch1/NCEPDEV/stmp4/Daniel.Holdaway/opt/modulefiles
+module load apps/jedi/intel-19.0.5.281
 
 module load nco
 

--- a/jobs/JJOB_PREP_3DVAR
+++ b/jobs/JJOB_PREP_3DVAR
@@ -6,8 +6,8 @@ set -e
 # Prep SOCA Static B and grid
 
 module purge
-module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles/
-module load jedi-intel-17.0.5.239
+module use -a /scratch1/NCEPDEV/stmp4/Daniel.Holdaway/opt/modulefiles
+module load apps/jedi/intel-19.0.5.281
 
 echo $RUNCDATE
 

--- a/jobs/JJOB_PREP_LETKF
+++ b/jobs/JJOB_PREP_LETKF
@@ -12,8 +12,8 @@ echo 'Run Directory: ' $RUNCDATE
 echo ''
 
 module purge
-module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles/
-module load jedi-intel-17.0.5.239
+module use -a /scratch1/NCEPDEV/stmp4/Daniel.Holdaway/opt/modulefiles
+module load apps/jedi/intel-19.0.5.281
 
 rename_func () { for files in $1; do cp $files ${files:0:(${#files}-28)}'nc'; done }
 

--- a/jobs/JJOB_PREP_SOCA
+++ b/jobs/JJOB_PREP_SOCA
@@ -11,8 +11,8 @@ cat <<EOF
 EOF
 
 module purge
-module use -a /scratch2/NCEPDEV/marine/marineda/modulefiles/
-module load jedi-intel-17.0.5.239
+module use -a /scratch1/NCEPDEV/stmp4/Daniel.Holdaway/opt/modulefiles
+module load apps/jedi/intel-19.0.5.281
 
 echo $RUNCDATE
 


### PR DESCRIPTION
Motivations
----------------
- Use a more recent version of soca-bundle, which requires a different set of modules
- Switch to a more recent intel compiler (intel 19). However, targeting ultimately the default (intel-18) compiler is the goal and will be addressed in a furture PR, when the issues with intel 18 are sorted out.

What was done
-----------------------
- Switch to using the intel-19 based modules (built by Dan using the jedi-stack)
-  Minor updates to the yaml files to reflect the switch from soca-bundle master to release/stable-nightly 

Dependencies
--------------------
- This PR is paired with the soca-config PR [soca-config PR#8](https://github.com/JCSDA/soca-config/pull/8) of the same name.
- The branch of the soca-bundle should be release/stable-nightly and has to be built with the updated modules
closes #105 