### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Description
+
+(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
+Provide a detailed description of what this PR does.  
+What bug does it fix, or what feature does it add?
+Is a change of answers expected from this PR?
+
+
+
+### Issue(s) addressed
+
+Link the issues to be closed with this PR, whether in this repository, or in another repository.
+(Remember, issues should always be created before starting work on a PR branch!)
+- fixes #<issue_number>
+- fixes JCSDA/soca-bundle/issues/<issue_number>
+
+
+
+## Testing
+
+How were these changes tested?
+What compilers / HPCs was it tested with?
+Are the changes covered by ctests? (If not, tests should be added first.)
+
+
+
+## Dependencies
+
+If testing this branch requires non-default branches in other repositories, list them.
+Those branches should have matching names for the automated TravisCI tests to pass
+
+Do PRs in upstream repositories need to be merged first?
+If so add the "waiting for other repos" label and list the upstream PRs
+- waiting on JCSDA/soca-bundle/pull/<pr_number>
+- waiting on JCSDA/oops/pull/<pr_number>
+


### PR DESCRIPTION
## Description
Because of the poor or lack of description of some of the PR in this repository, I propose to add a simple template that will remind us to provide the information that needs to be present to describe the work that is proposed to be merged.
Addresses issue #119. Each subsequent PR will be prefilled with a template that the developer will need to fillout.
Has no effect on the code!

### Issue(s) addressed
- fixes #119

## Testing
**N/A**

## Dependencies
**NONE**

