### PR TITLE
Bugfix/file existence

### DIFF
--- a/scripts/icec_prep_obs.sh
+++ b/scripts/icec_prep_obs.sh
@@ -18,7 +18,7 @@ if [ -f "${PREPROCobs}" ]; then
    # Create record dim
    ncks --mk_rec_dmn nlocs ${ObsRunDir}/ioda.icec.cat_l2.emc_LARGE.nc ${ObsRunDir}/icec-tmp.nc
    # Subsample
-   ncks -F -d nlocs,1,,5 ${ObsRunDir}/icec-tmp.nc ${PROCobs}
+   ncks -O -F -d nlocs,1,,5 ${ObsRunDir}/icec-tmp.nc ${PROCobs}
    rm ${ObsRunDir}/icec-tmp.nc
    rm ${ObsRunDir}/ioda.icec.cat_l2.emc_LARGE.nc
 

--- a/scripts/sst_prep_obs.sh
+++ b/scripts/sst_prep_obs.sh
@@ -91,7 +91,7 @@ else
       OBSDCOM=$DCOM_ROOT/${SSTsource}/$PDY              #FullPath of raw obs
    fi
 
-   if [ test -n "$(find $OBSDCOM -name "*$sat*" -print -quit)" ]; then 
+   if [  "$(find $OBSDCOM -name "*$sat*" -print -quit)" ]; then
    
       cd $OBSDCOM
       echo SST Observations from ${SSTsource}-${sat} for $PDY exist and will be processed, obs directory: `pwd` 

--- a/scripts/sst_prep_obs.sh
+++ b/scripts/sst_prep_obs.sh
@@ -90,7 +90,8 @@ else
    else
       OBSDCOM=$DCOM_ROOT/${SSTsource}/$PDY              #FullPath of raw obs
    fi
-   if [ -d "$OBSDCOM" ]; then
+
+   if [ test -n "$(find $OBSDCOM -maxdepth 1 -name "*$sat*" -print -quit)" ]; then 
    
       cd $OBSDCOM
       echo SST Observations from ${SSTsource}-${sat} for $PDY exist and will be processed, obs directory: `pwd` 
@@ -113,11 +114,7 @@ else
       thinning_func $subsample $skip
 
    else
-   
-      set -x
       echo There are no SST observations from ${SSTsource}-${sat} for ${PDY}  
-      set +x
    fi
-
 fi
 

--- a/scripts/sst_prep_obs.sh
+++ b/scripts/sst_prep_obs.sh
@@ -20,7 +20,7 @@ if $1; then
    # Create record dim
    ncks --mk_rec_dmn nlocs ${ObsRunDir}/ioda.${SSTsource}_LARGE.nc ${ObsRunDir}/sst-tmp.nc
    # Subsample
-   ncks -F -d nlocs,1,,$2 ${ObsRunDir}/sst-tmp.nc ${PROCobs}
+   ncks -O -F -d nlocs,1,,$2 ${ObsRunDir}/sst-tmp.nc ${PROCobs}
    # Cleanup
    rm ${ObsRunDir}/sst-tmp.nc
    rm ${ObsRunDir}/ioda.${SSTsource}_LARGE.nc
@@ -91,7 +91,7 @@ else
       OBSDCOM=$DCOM_ROOT/${SSTsource}/$PDY              #FullPath of raw obs
    fi
 
-   if [ test -n "$(find $OBSDCOM -maxdepth 1 -name "*$sat*" -print -quit)" ]; then 
+   if [ test -n "$(find $OBSDCOM -name "*$sat*" -print -quit)" ]; then 
    
       cd $OBSDCOM
       echo SST Observations from ${SSTsource}-${sat} for $PDY exist and will be processed, obs directory: `pwd` 


### PR DESCRIPTION
## Description

1. Since the PR #78 each observation type is defined by the satellite, provider, level, and sensor. Therefore, we have to check if at least one file of the observation of the specific type exists according to all the 4 criteria. 

The problem was identified with the AVHRR SSTs, when the AVHRR19 was missing but the AVHRRMTA was present, the code was trying to preprocess the AVHRR19 as well. 

2.  The **-O** flag to ncks was added to force overwriting of the ioda nc files, when the observation file already exists at the RUNCDATE directory.

### Issue(s) addressed

- fixes #121 

## Testing

How were these changes tested?
Run the 3dvar  with the start/end date:

SDATE: 2011-10-21t12:00:00
EDATE: 2011-10-22t12:00:00

What compilers / HPCs was it tested with? 
Default
Are the changes covered by ctests? (If not, tests should be added first.)
nope


## Dependencies
nonexisting