### PR TITLE
fix an issue in 3dvar layout file

### DIFF
--- a/workflow/layout/3dvar_only.yaml
+++ b/workflow/layout/3dvar_only.yaml
@@ -3,7 +3,7 @@ suite: !Cycle
 
       obs_prep: !Task
         <<: *shared_task_template
-        Trigger: !Depend  ( ~ suite.has_cycle('-24:00:00') | fcst_run.at('-24:00:00'))
+        Trigger: !Depend  ( ~ suite.has_cycle('-24:00:00') | da_3dvar_run.at('-24:00:00'))
         resources: !calc partition.resources.run_obs_prep
         config: [ base ]
         J_JOB: JJOB_OBS_PREP
@@ -43,13 +43,13 @@ suite: !Cycle
       #  config: [ base ]
       #  J_JOB: JJOB_FORECAST
 
-      post: !Task
-        <<: *shared_task_template
-        Trigger: !Depend  fcst_run
-        resources: !calc partition.resources.run_nothing
-#        rocoto_command: "echo post"
-        config: [ base ]
-        J_JOB: JJOB_POST
+      #post: !Task
+      #  <<: *shared_task_template
+      #  Trigger: !Depend  fcst_run
+      #  resources: !calc partition.resources.run_nothing
+#     #   rocoto_command: "echo post"
+      #  config: [ base ]
+      #  J_JOB: JJOB_POST
 
       final: !Task
         <<: *service_task_template


### PR DESCRIPTION
## Description

The 3dvar layout is wrong: some jobs are depending on fcst_run which is already commented out.
Fixed it.

## Testing
Run the 3dvar_only case to test.



## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names for the automated TravisCI tests to pass

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on JCSDA/soca-bundle/pull/<pr_number>
- waiting on JCSDA/oops/pull/<pr_number>

