### PR TITLE
putting all clones into checkout.sh script and removing them from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ During this process, three directories will be created:
 
 # Clone the soca-bundle (bundle of repositories necessary to build soca) and build soca
 
-0. `git clone --branch release/stable-nightly https://github.com/JCSDA/soca-bundle.git $CLONE_DIR/src/soca-bundle`
 1. Create the build directory for SOCA
    `mkdir -p $CLONE_DIR/build` \
    `cd $CLONE_DIR/build`
@@ -46,7 +45,6 @@ During this process, three directories will be created:
 
 # Clone and build the UMD-LETKF
  
-0. `git clone --recursive https://github.com/NOAA-EMC/UMD-LETKF.git $CLONE_DIR/src/letkf`  
 1. `cd $CLONE_DIR/src/letkf`  
 2. `git submodule update --init --recursive`   
 3. `mkdir -p $CLONE_DIR/build/letkf`

--- a/src/checkout.sh
+++ b/src/checkout.sh
@@ -32,3 +32,10 @@ else
 fi
 fi
 
+echo UMD-LETKF checkout ...  
+if [[ ! -d letkf ]] ; then
+    git clone --recursive https://github.com/NOAA-EMC/UMD-LETKF.git letkf 
+    cd ${topdir}
+else
+    echo 'Skip.  Directory letkf already exists.'
+fi


### PR DESCRIPTION
## Description

This unifies all cloning of dependent repositories into the checkout.sh script and removes them from the README

### Issue(s) addressed

- fixes #132 


## Testing

Just copy/pasting from README.md, did not test


## Dependencies

None

