### PR TITLE
Feature/fcst ens

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Otherwise the RUNCDATE is created automatically at stmpX directory of the user.
    Available cases:
    1. 3dvar.yaml
    2. letkf_only_exp.yaml
-   3. fcst_only.yaml 
-
+   3. fcst_only.yaml
+   
    Note: Each case files point to a corresponding layout file at $CLONE_DIR/workflow/layout. 
 
 5. Read output and run suggested command. Should be similar to: \
@@ -153,10 +153,13 @@ case:
     DA_TS: True     # T & S Insitu profiles 
     DA_ADT: True    # Absolute dynamic topography
     DA_ICEC: True   # Seaice fraction
+    NO_ENS_MBR: 2   # Size of ensemble, e.g. two members.
+    GROUPS: 2       # No of groups to run the ensemble, in this case, each member runs in a different group.
 
   places:
     workflow_file: layout/3dvar_only.yaml
 ```
+The default is 1 member to 1 group (deterministic run).
 
 # Currently Supported Models/Resolutions/Da algorithms
 | Cases | Forecast | 3DVAR | 3DHyb-EnVAR | LETKF |

--- a/jobs/JJOB_FCST_PREP
+++ b/jobs/JJOB_FCST_PREP
@@ -15,16 +15,39 @@ case $FCSTMODEL in
       ;;
    "MOM6CICE5")
        # If first cycle: Prepare hyb-coord and cice IC
-      if [ ! -d $RUNCDATE/../NEXT_IC ]; then
-        # TODO: Point to better IC's!
-        nextic=${RUNCDATE}/../NEXT_IC
-        mkdir -p $nextic
-        cp /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/mediator_* $nextic
-        cp /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/MOM*.nc $nextic
-        cp -r /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/restart $nextic
+
+      export ENSEND=$((NMEM_PGRP * ENSGRP))
+      export ENSBEG=$((ENSEND - NMEM_PGRP + 1))
+      
+      # TODO: Point to better IC'
+      if [ ! -d $RUNCDATE/../NEXT_IC ] & [ "$NO_ENS_MBR" -le "1" ]; then
+         nextic=$RUNCDATE/../NEXT_IC
+         mkdir -p $nextic
+         cp /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/mediator_* $nextic
+         cp /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/MOM*.nc $nextic
+         cp -r /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/restart $nextic
+      fi
+      if [ "$NO_ENS_MBR" -gt "1" ]; then
+         for MEMBER_NO in $(seq $ENSBEG $ENSEND); do
+            nextic="$RUNCDATE/../NEXT_IC/mem${MEMBER_NO}"
+            if [ ! -d $nextic ]; then
+               mkdir -p $nextic
+               cp /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/mediator_* $nextic
+               cp /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/MOM*.nc $nextic
+               cp -r /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/restart $nextic
+            fi
+         done
       fi
 
       # Prepare scratch dir to run mom6-cice5 forecast
-      ${ROOT_GODAS_DIR}/scripts/prep_forecast.sh
+      if [ "$NO_ENS_MBR" -le "1" ];then
+         ${ROOT_GODAS_DIR}/scripts/prep_forecast.sh 
+      else
+      # Get ENSBEG/ENSEND from ENSGRP and NMEM_EFCSGRP
+         for MEMBER_NO in $(seq $ENSBEG $ENSEND); do
+            ${ROOT_GODAS_DIR}/scripts/prep_forecast.sh -n $MEMBER_NO
+         done
+      fi
       ;;
+
 esac

--- a/jobs/JJOB_FCST_PREP
+++ b/jobs/JJOB_FCST_PREP
@@ -22,6 +22,9 @@ case $FCSTMODEL in
       # TODO: Point to better IC'
       if [ ! -d $RUNCDATE/../NEXT_IC ] & [ "$NO_ENS_MBR" -le "1" ]; then
          nextic=$RUNCDATE/../NEXT_IC
+cat <<EOF
+# Initial Conditions are copied from the static files
+EOF
          mkdir -p $nextic
          cp /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/mediator_* $nextic
          cp /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/MOM*.nc $nextic
@@ -31,6 +34,9 @@ case $FCSTMODEL in
          for MEMBER_NO in $(seq $ENSBEG $ENSEND); do
             nextic="$RUNCDATE/../NEXT_IC/mem${MEMBER_NO}"
             if [ ! -d $nextic ]; then
+cat <<EOF
+# Initial Conditions are copied from the static files
+EOF
                mkdir -p $nextic
                cp /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/mediator_* $nextic
                cp /scratch2/NCEPDEV/marine/marineda/soca-static/1440x1080x75/test-emc-m6c5/MOM*.nc $nextic
@@ -49,5 +55,4 @@ case $FCSTMODEL in
          done
       fi
       ;;
-
 esac

--- a/jobs/JJOB_FORECAST
+++ b/jobs/JJOB_FORECAST
@@ -35,11 +35,7 @@ case $FCSTMODEL in
       module purge
       source $MOD_PATH/godas.fcst
       module list
-
-      #TODO: DATA defined multiple places...
-      DATA=$RUNCDATE/fcst
-      FORECAST_EXE=${ROOT_GODAS_DIR}/src/DATM-MOM6-CICE5.fd/NEMS/exe/nems_datm_mom6_cice5.x
-
+      
       #TODO: This should be a configuration calculation/currently defined in multiple places
       #for now all these values should be hardcoded, these are things that should be controld
       #by global-workflow forecast anyways
@@ -50,18 +46,46 @@ case $FCSTMODEL in
 
       NPE_FCST=${NTASKS_TOT:-240}
 
+      #TODO: DATA defined multiple places...
+      DATA=$RUNCDATE/fcst
+      FORECAST_EXE=${ROOT_GODAS_DIR}/src/DATM-MOM6-CICE5.fd/NEMS/exe/nems_datm_mom6_cice5.x
 
-      echo "Forecast Run Directory: $DATA"
-      echo "Forecast exe: $FORECAST_EXE"
-      echo "Number of tasks: $NPE_FCST"
-      echo "Run command: srun -n $NPE_FCST ${FORECAST_EXE}"
+      if [ "$NO_ENS_MBR" -le "1" ];then
+         echo "Forecast Run Directory: $DATA"
+         echo "Forecast exe: $FORECAST_EXE"
+         echo "Number of tasks: $NPE_FCST"
+         echo "Run command: srun -n $NPE_FCST ${FORECAST_EXE}"
 
-      cd $DATA
-      srun -n $NPE_FCST ${FORECAST_EXE}
+         cd $DATA
+         srun -n $NPE_FCST ${FORECAST_EXE}
 
-      echo "Finished forecast, now copy output using script: ${ROOT_GODAS_DIR}/scripts/post_forecast.sh"
+          echo "Finished forecast, now copy output using script: ${ROOT_GODAS_DIR}/scripts/post_forecast.sh"
       # Copy ICs for next cycle, copy output to save location, cleanup forecast directory
-      ${ROOT_GODAS_DIR}/scripts/post_forecast.sh
+         ${ROOT_GODAS_DIR}/scripts/post_forecast.sh
+
+      else
+      # Get ENSBEG/ENSEND from ENSGRP and NMEM_EFCSGRP
+         export ENSEND=$((NMEM_PGRP * ENSGRP))
+         export ENSBEG=$((ENSEND - NMEM_PGRP + 1))
+         echo ENSGRP $ENSGRP ENSBEG $ENSBEG ENSEND $ENSEND
+         for MEMBER_NO in $(seq $ENSBEG $ENSEND); do
+            DATAtmp=$DATA"/mem"$MEMBER_NO
+            echo Member to be prepared: $MEMBER_NO
+            echo "Forecast Run Directory: $DATAtmp"
+            echo "Forecast exe: $FORECAST_EXE"
+            echo "Number of tasks: $NPE_FCST"
+            echo "Run command: srun -n $NPE_FCST ${FORECAST_EXE}"
+
+            cd $DATAtmp
+            srun -n $NPE_FCST ${FORECAST_EXE}
+
+            echo "Finished forecast, now copy output using script: ${ROOT_GODAS_DIR}/scripts/post_forecast.sh -n $MEMBER_NO"
+
+      # Copy ICs for next cycle, copy output to save location, cleanup forecast directory
+            ${ROOT_GODAS_DIR}/scripts/post_forecast.sh -n $MEMBER_NO
+
+         done
+      fi
 
       echo "End of Forecast for $CDATE"
       ;;

--- a/scripts/post_forecast.sh
+++ b/scripts/post_forecast.sh
@@ -1,14 +1,8 @@
-#! /bin/sh
+#! /bin/sh -l
 
 
 echo "Entering post run forecast script"
 
-
-######################################################################
-######################################################################
-# Copy IC/Restarts:                                                  #
-######################################################################
-######################################################################
 while getopts "n:" opt; do
    case $opt in
       n) mbr=("$OPTARG");;
@@ -16,13 +10,18 @@ while getopts "n:" opt; do
 done
 shift $((OPTIND -1))
 
+
+######################################################################
+######################################################################
+# Copy IC/Restarts:                                                  #
+######################################################################
+######################################################################
+
 if [ -z "$mbr" ]
 then 
-   echo mbr is empty
    DATA=${RUNCDATE}/fcst
    nextic=$RUNCDATE/../NEXT_IC
 else
-   echo mbr has value: $mbr
    DATA=${RUNCDATE}/fcst/mem$mbr
    nextic=$RUNCDATE/../NEXT_IC/mem$mbr
 fi
@@ -31,7 +30,7 @@ fi
 ##  if [ $inistep = 'cold' ]; then
 ##   cp $DATA/mediator_* $ROTDIR/$CDUMP.$PDY/$cyc/
 
-mkdir -p ${next_ic}/restart
+mkdir -p ${nextic}/restart
 
 echo "Forecast Run Dir is: $DATA"
 echo "NEXT_IC dir is: ${nextic}"

--- a/scripts/post_forecast.sh
+++ b/scripts/post_forecast.sh
@@ -9,24 +9,39 @@ echo "Entering post run forecast script"
 # Copy IC/Restarts:                                                  #
 ######################################################################
 ######################################################################
+while getopts "n:" opt; do
+   case $opt in
+      n) mbr=("$OPTARG");;
+   esac
+done
+shift $((OPTIND -1))
 
-DATA=${RUNCDATE}/fcst
+if [ -z "$mbr" ]
+then 
+   echo mbr is empty
+   DATA=${RUNCDATE}/fcst
+   nextic=$RUNCDATE/../NEXT_IC
+else
+   echo mbr has value: $mbr
+   DATA=${RUNCDATE}/fcst/mem$mbr
+   nextic=$RUNCDATE/../NEXT_IC/mem$mbr
+fi
 
 #TODO: If a cold mediator start, copy the mediator files:
 ##  if [ $inistep = 'cold' ]; then
 ##   cp $DATA/mediator_* $ROTDIR/$CDUMP.$PDY/$cyc/
 
-mkdir -p $RUNCDATE/../NEXT_IC/restart
+mkdir -p ${next_ic}/restart
 
 echo "Forecast Run Dir is: $DATA"
-echo "NEXT_IC dir is: $RUNCDATE/../NEXT_IC"
+echo "NEXT_IC dir is: ${nextic}"
 
 echo "Copy restarts for ice"
-cp $DATA/restart/*  $RUNCDATE/../NEXT_IC/restart/
+cp $DATA/restart/* ${nextic}/restart/
 echo "Copy mediator restarts"
-cp $DATA/mediator_* $RUNCDATE/../NEXT_IC/
+cp $DATA/mediator_* ${nextic}/
 echo "Copy MOM6 Restarts"
-cp $DATA/MOM6_RESTART/* $RUNCDATE/../NEXT_IC/
+cp $DATA/MOM6_RESTART/* ${nextic}/
 
 
 #  #TODO: THE RESTARTS SHOULD BE COPIED INTO THE NEXT $cyc file? or PDY?

--- a/scripts/prep_forecast.sh
+++ b/scripts/prep_forecast.sh
@@ -22,12 +22,10 @@ shift $((OPTIND -1))
 
 if [ -z "$mbr" ]
 then 
-   echo mbr is empty
    DATA=${RUNCDATE}/fcst
    nextic=$RUNCDATE/../NEXT_IC
    keepic=$RUNCDATE/../${CDATE}_IC
 else
-   echo mbr has value: $mbr
    DATA=${RUNCDATE}"/fcst/mem"$mbr
    nextic=$RUNCDATE/../NEXT_IC/mem$mbr
    keepic=$RUNCDATE/../${CDATE}_IC/   

--- a/scripts/prep_forecast.sh
+++ b/scripts/prep_forecast.sh
@@ -13,6 +13,25 @@
 ######################################################################
 ######################################################################
 
+while getopts "n:" opt; do
+   case $opt in
+      n) mbr=("$OPTARG");;
+   esac
+done
+shift $((OPTIND -1))
+
+if [ -z "$mbr" ]
+then 
+   echo mbr is empty
+   DATA=${RUNCDATE}/fcst
+   nextic=$RUNCDATE/../NEXT_IC
+   keepic=$RUNCDATE/../${CDATE}_IC
+else
+   echo mbr has value: $mbr
+   DATA=${RUNCDATE}"/fcst/mem"$mbr
+   nextic=$RUNCDATE/../NEXT_IC/mem$mbr
+   keepic=$RUNCDATE/../${CDATE}_IC/   
+fi
 #Variables which need to be defined: 
 
 #Generic variables 
@@ -24,8 +43,6 @@ FIXcice=${ROOT_GODAS_DIR}/fix/CICE_FIX_mx025
 FHMAX=${FHMAX:-24} #total forecast length in hours
 restart_interval=${restart_interval:-86400}  # number of seconds for writing restarts (for non-cold start) default to 1 day interval
 
-DATA=${RUNCDATE}/fcst
-
 echo "CDATE is $CDATE"
 echo "RUNCDATE is ${RUNCDATE}" 
 echo "DATA is ${DATA}"
@@ -33,7 +50,6 @@ echo "SCRIPTDIR is $SCRIPTDIR"
 echo "TEMPLATEDIR is $TEMPLATEDIR"
 echo "FHMAX is $FHMAX"
 echo "restart interval is ${restart_interval}"
-
 
 #################################
 # Variables that are for the most part hard coded but could be pulled out and configured/etc. 
@@ -111,7 +127,7 @@ echo "Set up Directories"
 
 #Set up forecast run directory:
  
-DATA=${RUNCDATE}/fcst
+#DATA=${RUNCDATE}/fcst
 if [ ! -d $DATA ]; then mkdir -p $DATA; fi
 if [ ! -d $DATA/INPUT ]; then mkdir -p $DATA/INPUT; fi
 if [ ! -d $DATA/restart ]; then mkdir -p $DATA/restart; fi
@@ -303,7 +319,7 @@ tr_pond_lvl=${tr_pond_lvl:-".true."} # Use level melt ponds tr_pond_lvl=true
 # restart_pond_lvl (if tr_pond_lvl=true):
 #   -- if true, initialize the level ponds from restart (if runtype=continue) 
 #   -- if false, re-initialize level ponds to zero (if runtype=initial or continue)  
-if [ -d $RUNCDATE/../NEXT_IC ]; then
+if [ -d $nextic ]; then
   #continuing run "hot start" 
   RUNTYPE='continue'
   USE_RESTART_TIME='.false.'
@@ -437,9 +453,9 @@ echo "Copy mediator restart files"
 if [ $inistep = 'cold' ]; then
   echo "mediator cold start run sequence... error currently not set up for this"
 else
-  if [ -d $RUNCDATE/../NEXT_IC ]; then 
+  if [ -d $nextic ]; then 
     #cp $ROTDIR/$CDUMP.$PDY/$cyc/mediator_* $DATA/
-    cp $RUNCDATE/../NEXT_IC/mediator_* $DATA/
+    cp $nextic/mediator_* $DATA/
   else 
     if [ $NEARESTCDATE = '2011100100' ]; then
       echo "Copying mediator restarts for $NEARESTCDATE from regtest area"
@@ -459,10 +475,10 @@ fi
 echo "Copy MOM6 ICs" 
 
 # Copy MOM6 ICs
-if [ -d $RUNCDATE/../NEXT_IC ]; then
+if [ -d $nextic ]; then
     # Get IC from previous cycle
     ##cp ../NEXT_IC/cice_bkg.nc $RUNCDATE/INPUT_MOM6/cice_bkg.nc
-    cp $RUNCDATE/../NEXT_IC/MOM*.nc $DATA/INPUT/
+    cp $nextic/MOM*.nc $DATA/INPUT/
 else 
 
   echo "CICE5 IC is being copied from benchmark area for CDATE $CDATE" 
@@ -479,9 +495,9 @@ fi
 
 echo "Copy CICE5 ICs" 
 
-if [ -d $RUNCDATE/../NEXT_IC ]; then
+if [ -d $nextic ]; then
   #cp $ROTDIR/$CDUMP.$PDY/$cyc/$iceic $DATA/restart/
-  cp $RUNCDATE/../NEXT_IC/restart/* $DATA/restart/
+  cp $nextic/restart/* $DATA/restart/
 else 
   echo "CICE5 IC is being copied from benchmark area for CDATE $CDATE" 
   echo "Note these only exist for the 01 and 15 ths of every month" 
@@ -497,8 +513,9 @@ fi
 # 4.4 Remove NEXT_IC DIR                                             #
 ######################################################################
 
-echo "removing NEXT_IC DIR" 
-rm -rf $RUNCDATE/../NEXT_IC
+#echo "removing NEXT_IC DIR"
+
+mv $nextic $keepic
 
 ######################################################################
 #   End of prep_forecast.sh                                          #

--- a/scripts/prep_forecast.sh
+++ b/scripts/prep_forecast.sh
@@ -125,7 +125,6 @@ echo "Set up Directories"
 
 #Set up forecast run directory:
  
-#DATA=${RUNCDATE}/fcst
 if [ ! -d $DATA ]; then mkdir -p $DATA; fi
 if [ ! -d $DATA/INPUT ]; then mkdir -p $DATA/INPUT; fi
 if [ ! -d $DATA/restart ]; then mkdir -p $DATA/restart; fi
@@ -135,7 +134,6 @@ if [ ! -d $DATA/OUTPUT ]; then mkdir -p $DATA/OUTPUT; fi
 if [ ! -d $DATA/MOM6_OUTPUT ]; then mkdir -p $DATA/MOM6_OUTPUT; fi
 if [ ! -d $DATA/MOM6_RESTART ]; then mkdir -p $DATA/MOM6_RESTART; fi
 if [ ! -d $DATA/DATM_INPUT ]; then mkdir -p $DATA/DATM_INPUT; fi
-
 
 # Go to Run Directory (DATA)         
 cd $DATA 

--- a/workflow/cases/fcst_only.yaml
+++ b/workflow/cases/fcst_only.yaml
@@ -7,7 +7,7 @@ case:
     FCSTMODEL: MOM6CICE5 # MOM6solo
   
   da_settings:
-    NO_ENS_MBR: 4
+    NO_ENS_MBR: 2
     GROUPS: 2
   
   places:

--- a/workflow/cases/fcst_only.yaml
+++ b/workflow/cases/fcst_only.yaml
@@ -5,6 +5,10 @@ case:
     godas_cyc: 1 # selection of godas cycle: 1(default)- 24h; 2 - 12h; 4 - 6h
     resolution: Ocean025deg #Ocean3deg # Ocean1deg or Ocean025deg 
     FCSTMODEL: MOM6CICE5 # MOM6solo
-
+  
+  da_settings:
+    NO_ENS_MBR: 4
+    GROUPS: 2
+  
   places:
     workflow_file: layout/fcst_only.yaml

--- a/workflow/defaults/da.yaml
+++ b/workflow/defaults/da.yaml
@@ -26,7 +26,7 @@ da_settings_default: &da_settings_default
   DA_WNDW_OFST: 48
   DA_TS_ONLY:   0
 # Number of ensemble members
-  NO_ENS_MBR: 15
+  NO_ENS_MBR: 3 
   GROUPS: 3
   NMEM_PGRP: !calc ( NO_ENS_MBR // GROUPS )
 # Forecast model (options: MOM6solo, MOM6CICE5)

--- a/workflow/defaults/da.yaml
+++ b/workflow/defaults/da.yaml
@@ -26,8 +26,8 @@ da_settings_default: &da_settings_default
   DA_WNDW_OFST: 48
   DA_TS_ONLY:   0
 # Number of ensemble members
-  NO_ENS_MBR: 3 
-  GROUPS: 3
+  NO_ENS_MBR: 1 
+  GROUPS: 1
   NMEM_PGRP: !calc ( NO_ENS_MBR // GROUPS )
 # Forecast model (options: MOM6solo, MOM6CICE5)
 #  FCSTMODEL: MOM6solo

--- a/workflow/layout/fcst_only.yaml
+++ b/workflow/layout/fcst_only.yaml
@@ -1,20 +1,45 @@
 suite: !Cycle
       <<: *suite_defaults
-
-      fcst_prep: !Task
-        <<: *shared_task_template
-        #TODO: depend on previous cycle in case cycle is more than 1 day (ie running one really long run)
+      #TODO: depend on previous cycle in case cycle is more than 1 day (ie running one really long run)
+      fcst_prep: !TaskArray
         Trigger: !Depend  ( ~ suite.has_cycle('-24:00:00') | fcst_run.at('-24:00:00'))
-        resources: !calc partition.resources.run_fcst_prep
-        config: [ base ]
-        J_JOB: JJOB_FCST_PREP
+        Dimensions:
+          groupid: !calc tools.seq(1,doc.da_settings.GROUPS,1)
+        fcst_prep_grp: !TaskElement
+          <<: *shared_task_template
+          Foreach: [ groupid ]
+          Name: !expand "pgrp{dimval.groupid}"
+          resources: !calc partition.resources.run_fcst_prep
+          config: [ base ]
+          J_JOB: JJOB_FCST_PREP
+          ENSGRP: !expand "{dimval.groupid:02d}"
+          rocoto_command: !expand >-
+            {rocoto_load_modules} ;
+            {rocoto_config_source} ;
+            /usr/bin/env ENSGRP={ENSGRP} &ROOT_GODAS_DIR;/jobs/{J_JOB}
+          ecflow_command: !expand |
+            export ENSGRP={ENSGRP}
+            $ROOT_GODAS_DIR/jobs/{J_JOB}
 
-      fcst_run: !Task
-        <<: *exclusive_task_template
-        Trigger: !Depend  fcst_prep
-        resources: !calc partition.resources.run_fcst
-        config: [ base ]
-        J_JOB: JJOB_FORECAST
+      fcst_run: !TaskArray
+        Trigger: !Depend fcst_prep
+        Dimensions:
+          groupid: !calc tools.seq(1,doc.da_settings.GROUPS,1)
+        fcst_run_grp: !TaskElement
+          <<: *shared_task_template
+          Foreach: [ groupid ]
+          Name: !expand "pgrp{dimval.groupid}"
+          resources: !calc partition.resources.run_fcst
+          config: [ base ]
+          J_JOB: JJOB_FORECAST
+          ENSGRP: !expand "{dimval.groupid:02d}"
+          rocoto_command: !expand >-
+            {rocoto_load_modules} ;
+            {rocoto_config_source} ;
+            /usr/bin/env ENSGRP={ENSGRP} &ROOT_GODAS_DIR;/jobs/{J_JOB}
+          ecflow_command: !expand |
+            export ENSGRP={ENSGRP}
+            $ROOT_GODAS_DIR/jobs/{J_JOB}
 
       post: !Task
         <<: *shared_task_template


### PR DESCRIPTION
## Description

With this PR, the forecast case and all the cases using the forecast are able to run an ensemble by modifying the cases/*.yaml, by adding the NO_ENS_MBR and GROUPS, see the workflow/cases/fcst_only.yaml for an example.

This update is focused on DATM-MOM6-CICE5 model.

By adding ensemble model run capability we are able to run an ensemble forecast or/and DA through the workflow.

### Issue(s) addressed
Ensemble forecast is now supported

## Testing
To test, the reviewers should run  for the  DATM-MOM6-CICE5 model, the following cases: 

1. The forecast case with one member and get identical results with the develop forecast case.
2. The forecast case with multiple members and get identical results among the members and the develop forecast case.
3. The 3dvar and get identical results with the develop 3dvar case.

Known Issues:
Select NO_ENS_MBR, GROUPS in such a way mod(NO_ENS_MBR, GROUPS)=0

