### PR TITLE
Feature/mom6tools in workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ During this process, three directories will be created:
    `make -j2`
 7. `ln -fs $CLONE_DIR/build/letkf/bin/letkfdriver $CLONE_DIR/build/bin/letkfdriver`
 
+# Copy the mom6-tools.plot to the bin
+0. cp $CLONE_DIR/src/mom6-tools.plot/*.py $CLONE_DIR/build/bin/ 
+
 # Preparing the workflow
 0. Create the directory that the workflow will be deployed:
    `mkdir -p PROJECT_DIR`

--- a/README.md
+++ b/README.md
@@ -174,5 +174,5 @@ The default is 1 member to 1 group (deterministic run).
 
 # Post-processing Plot Options
 
-0. scripts/post_plot.sh has been updated to be included in workflow. However, the line to trigger the script in JJOB_POST is not turned on yet due to memory management issue of hera system. However, offline.plot.sh in src/mom6-tools directory can be used to generate post processing plots: see the instruction [here](./src/mom6-tools.plot/README.md).
+0. scripts/post_plot.sh has been updated and included in rocoto workflow. In post processing run, sea ice fraction, SSH, SST, and time_mean figures will be created in $RUNCDATE/Figures directory. Additional offline post processing and plotting tools are available in src/mom6-tools directory: see the instruction [here](./src/mom6-tools.plot/README.md).
 

--- a/README.md
+++ b/README.md
@@ -174,5 +174,5 @@ The default is 1 member to 1 group (deterministic run).
 
 # Post-processing Plot Options
 
-0. scripts/post_plot.sh has been updated to be included in workflow. However, the line to trigger the script in JJOB_POST is not turned on yet due to memory management issue of hera system. offline.plot.sh in src/mom6-tools directory can be used to generate post processing plots: see the instruction [here](./src/mom6-tools.plot/README.md).
+0. scripts/post_plot.sh has been updated to be included in workflow. However, the line to trigger the script in JJOB_POST is not turned on yet due to memory management issue of hera system. However, offline.plot.sh in src/mom6-tools directory can be used to generate post processing plots: see the instruction [here](./src/mom6-tools.plot/README.md).
 

--- a/README.md
+++ b/README.md
@@ -174,4 +174,5 @@ The default is 1 member to 1 group (deterministic run).
 
 # Post-processing Plot Options
 
-0. Not included in workflow yet, but mom6-tools-based python scripts are available to make plots of model diagnostic output files: see the instruction [here](./src/mom6-tools.plot/README.md).
+0. scripts/post_plot.sh has been updated to be included in workflow. However, the line to trigger the script in JJOB_POST is not turned on yet due to memory management issue of hera system. offline.plot.sh in src/mom6-tools directory can be used to generate post processing plots: see the instruction [here](./src/mom6-tools.plot/README.md).
+

--- a/jobs/JJOB_POST
+++ b/jobs/JJOB_POST
@@ -26,7 +26,7 @@ case $FCSTMODEL in
        ;;
    "MOM6CICE5")
        # TODO: Keep something from fcst?
-       #if [ -d $RUNCDATE/fcst ]; then rm -rf $RUNCDATE/fcst; fi
+       if [ -d $RUNCDATE/fcst ]; then rm -rf $RUNCDATE/fcst; fi
        if [ -d $RUNCDATE/test-emc-m6c5 ]; then rm -rf $RUNCDATE/test-emc-m6c5; fi
        ;;
 esac

--- a/jobs/JJOB_POST
+++ b/jobs/JJOB_POST
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+#set -e
 
 cat <<EOF
 #================================================================================
@@ -11,7 +11,7 @@ cat <<EOF
 EOF
 # Plot results
 source $MOD_PATH/godas.python
-${ROOT_GODAS_DIR}/scripts/post_plot.sh
+#${ROOT_GODAS_DIR}/scripts/post_plot.sh
 
 # Remove BUMP files
 # TODO: After update to soca, bump only needs to be initialized once
@@ -26,7 +26,7 @@ case $FCSTMODEL in
        ;;
    "MOM6CICE5")
        # TODO: Keep something from fcst?
-       if [ -d $RUNCDATE/fcst ]; then rm -rf $RUNCDATE/fcst; fi
+       #if [ -d $RUNCDATE/fcst ]; then rm -rf $RUNCDATE/fcst; fi
        if [ -d $RUNCDATE/test-emc-m6c5 ]; then rm -rf $RUNCDATE/test-emc-m6c5; fi
        ;;
 esac

--- a/jobs/JJOB_POST
+++ b/jobs/JJOB_POST
@@ -9,6 +9,9 @@ cat <<EOF
 #================================================================================
 #================================================================================
 EOF
+# Plot results
+source $MOD_PATH/godas.python
+${ROOT_GODAS_DIR}/scripts/post_plot.sh
 
 # Remove BUMP files
 # TODO: After update to soca, bump only needs to be initialized once

--- a/jobs/JJOB_POST
+++ b/jobs/JJOB_POST
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -e
+set -e
 
 cat <<EOF
 #================================================================================
@@ -11,7 +11,7 @@ cat <<EOF
 EOF
 # Plot results
 source $MOD_PATH/godas.python
-#${ROOT_GODAS_DIR}/scripts/post_plot.sh
+${ROOT_GODAS_DIR}/scripts/post_plot.sh
 
 # Remove BUMP files
 # TODO: After update to soca, bump only needs to be initialized once

--- a/scripts/post_plot.sh
+++ b/scripts/post_plot.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -l
+
+echo "post_plot_fcst.sh starts"
+echo "CDATE is " $CDATE
+cd $RUNCDATE
+echo "Location of experiment: "`pwd` 
+
+IceAnlDir=$RUNCDATE/Data
+OceanFcstDir=$RUNCDATE/fcst
+FiguresDir=$RUNCDATE/Figures
+
+[ ! -d $FiguresDir ] && mkdir -p $FiguresDir
+
+echo "Figures are created at $FigureDir"
+
+GridFile=$(find `pwd` -name 'ocn_*.nc' -print -quit)
+
+# 1. Plot Ice analysis
+cp -rf $IceAnlDir/cic.socagodas.an.*.nc $OceanFcstDir
+
+python $SOCA_EXEC/ice.plot.py                      \
+         -grid $GridFile                           \
+         -data $OceanFcstDir/cic.socagodas.an.*.nc \
+         -figs_path $FiguresDir                    \
+         -var hice aice
+
+# 2. Plot the ocean fcst 
+python $SOCA_EXEC/sfc.plot.py                      \
+         -grid $GridFile                           \
+         -data $OceanFcstDir/ocn_*.nc              \
+         -figs_path  $FiguresDir 
+
+# 3. Plot time averages
+[ ! -d $FiguresDir ] && mkdir -p $FiguresDir/time_mean
+
+python $SOCA_EXEC/sfc.time.plot.py                 \
+         -grid $GridFile                           \
+         -data $OceanFcstDir/ocn_*.nc              \
+         -figs_path $FiguresDir/time_mean
+

--- a/scripts/post_plot.sh
+++ b/scripts/post_plot.sh
@@ -19,11 +19,12 @@ if [[ -z "$GridFile" ]] ; then
     exit 1
 fi
 
+export QT_QPA_PLATFORM=offscreen
 # 1. Plot Ice analysis
 files2plot=( "$IceAnlDir"/cic.socagodas.an.*.nc )
 if [ -e "${files2plot[0]}" ]; then
     cp -rf $IceAnlDir/cic.socagodas.an.*.nc $OceanFcstDir
-    python $SOCA_EXEC/ice.plot.py                    \
+    ipython -- $SOCA_EXEC/ice.plot.py                    \
            -grid $GridFile                           \
            -data $OceanFcstDir/cic.socagodas.an.*.nc \
            -figs_path $FiguresDir                    \
@@ -33,7 +34,7 @@ fi
 # 2. Plot the ocean fcst 
 files2plot=( "$OceanFcstDir"/ocn_*.nc )
 if [ -e "${files2plot[0]}" ]; then
-    python $SOCA_EXEC/sfc.plot.py                    \
+    ipython -- $SOCA_EXEC/sfc.plot.py                    \
 	   -grid $GridFile                           \
 	   -data $OceanFcstDir/ocn_*.nc              \
 	   -figs_path $FiguresDir 
@@ -44,7 +45,7 @@ fi
 
 files2plot=( "$OceanFcstDir"/ocn_*.nc )
 if [ -e "${files2plot[0]}" ]; then
-    python $SOCA_EXEC/sfc.time.plot.py               \
+    ipython -- $SOCA_EXEC/sfc.time.plot.py               \
            -grid $GridFile                           \
            -data $OceanFcstDir/ocn_*.nc              \
            -figs_path $FiguresDir/time_mean

--- a/scripts/post_plot.sh
+++ b/scripts/post_plot.sh
@@ -13,28 +13,39 @@ FiguresDir=$RUNCDATE/Figures
 
 echo "Figures are created at $FigureDir"
 
-GridFile=$(find `pwd` -name 'ocn_*.nc' -print -quit)
+GridFile=$(find $OceanFcstDir -name 'ocn_*.nc' -print -quit)
+if [[ -z "$GridFile" ]] ; then
+    echo "Grid file containing geolon/geolat does not exist ..."
+    exit 1
+fi
 
 # 1. Plot Ice analysis
-cp -rf $IceAnlDir/cic.socagodas.an.*.nc $OceanFcstDir
-
-python $SOCA_EXEC/ice.plot.py                      \
-         -grid $GridFile                           \
-         -data $OceanFcstDir/cic.socagodas.an.*.nc \
-         -figs_path $FiguresDir                    \
-         -var hice aice
+files2plot=( "$IceAnlDir"/cic.socagodas.an.*.nc )
+if [ -e "${files2plot[0]}" ]; then
+    cp -rf $IceAnlDir/cic.socagodas.an.*.nc $OceanFcstDir
+    python $SOCA_EXEC/ice.plot.py                    \
+           -grid $GridFile                           \
+           -data $OceanFcstDir/cic.socagodas.an.*.nc \
+           -figs_path $FiguresDir                    \
+           -var hice aice
+fi
 
 # 2. Plot the ocean fcst 
-python $SOCA_EXEC/sfc.plot.py                      \
-         -grid $GridFile                           \
-         -data $OceanFcstDir/ocn_*.nc              \
-         -figs_path  $FiguresDir 
+files2plot=( "$OceanFcstDir"/ocn_*.nc )
+if [ -e "${files2plot[0]}" ]; then
+    python $SOCA_EXEC/sfc.plot.py                    \
+	   -grid $GridFile                           \
+	   -data $OceanFcstDir/ocn_*.nc              \
+	   -figs_path $FiguresDir 
+fi
 
 # 3. Plot time averages
 [ ! -d $FiguresDir ] && mkdir -p $FiguresDir/time_mean
 
-python $SOCA_EXEC/sfc.time.plot.py                 \
-         -grid $GridFile                           \
-         -data $OceanFcstDir/ocn_*.nc              \
-         -figs_path $FiguresDir/time_mean
-
+files2plot=( "$OceanFcstDir"/ocn_*.nc )
+if [ -e "${files2plot[0]}" ]; then
+    python $SOCA_EXEC/sfc.time.plot.py               \
+           -grid $GridFile                           \
+           -data $OceanFcstDir/ocn_*.nc              \
+           -figs_path $FiguresDir/time_mean
+fi

--- a/scripts/templates/diag_table_template
+++ b/scripts/templates/diag_table_template
@@ -19,6 +19,8 @@
  "ocean_model", "wet_v",       "wet_v",       "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
  "ocean_model", "sin_rot",     "sin_rot",     "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
  "ocean_model", "cos_rot",     "cos_rot",     "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "area_t",      "area_t",      "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+
 
 # ocean output TSUV and others
  "ocean_model", "SSH",       "SSH",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
@@ -31,6 +33,7 @@
  "ocean_model", "ePBL_h_ML", "ePBL",     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model", "MLD_003",   "MLD_003",  "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2 
  "ocean_model", "MLD_0125",  "MLD_0125", "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "vmo",       "vmo",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
 
 # save daily SST
  "ocean_model", "geolon",      "geolon",      "SST%4yr%2mo%2dy", "all", .false., "none", 2
@@ -43,6 +46,7 @@
  "ocean_model_z","vo","vo"      ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model_z","so","so"      ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model_z","temp","temp"  ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model_z","e","e"        ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
 
 # forcing
  "ocean_model", "taux",      "taux",                     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
@@ -58,6 +62,9 @@
  "ocean_model", "fprec",     "fprec",                    "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model", "LwLatSens", "LwLatSens",                "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model", "Heat_PmE",  "Heat_PmE",                 "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "hfds",      "hfds",                     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "PRCmE",      "PRCmE",                   "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+
 
 #=============================================================================================
 #=============================================================================================

--- a/scripts/templates/diag_table_template
+++ b/scripts/templates/diag_table_template
@@ -34,6 +34,7 @@
  "ocean_model", "MLD_003",   "MLD_003",  "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2 
  "ocean_model", "MLD_0125",  "MLD_0125", "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model", "vmo",       "vmo",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "umo",       "umo",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
 
 # save daily SST
  "ocean_model", "geolon",      "geolon",      "SST%4yr%2mo%2dy", "all", .false., "none", 2

--- a/src/mom6-tools.plot/README.md
+++ b/src/mom6-tools.plot/README.md
@@ -1,12 +1,12 @@
 0-1. This directory contains python plotting scripts based on mom6-tools. Note that scripts run with local cartopy shapefiles in /scratch2/NCEPDEV/marineda/common/cartopy.
 
-0-2. offline.plot.sh can be used to generate post processing plots. This script can be copied to any local directory and run with input path of each case (or path of PROJECT_DIR/WORKFLOW_NAME):
+0-2. offline.plot.sh can be used to generate post processing plots. This script can be copied to any local directory and run with input path of each experiment case (or PROJECT_DIR/WORKFLOW_NAME):
 
 offline.plot.sh path_for_case1 path_for_case2
 
 If multiple case path inputs are given, the script will go through loops to create figure directories for each run of cases. In $RUNCDATE/Figures, sea ice fraction, SST, SSH, and time_mean figures will be created. Detail instruction to run each plotting python script is given below:
 
-0-2-1. Python scripts require two input arguments: grid and data file names. Multiple data files can be used with wildcard (*) input for data file names. As of now (01/07/2020), diag_table files are not fully updated for variables needed in mom6-tools modules yet. For the time being, users can utilize ocean_geometry.nc in /scratch2/NCEPDEV/marineda/common. Test runs for plotting examples are:
+0-2-1. Python plotting scripts of mom6-tools require two input arguments: grid and data file names. Multiple data files can be used with wildcard (*) input for data file names. We keep -grid argument to allow fexibility of using any source of geolon/geolat information. If diagnostic data files contain geolon/geolat variables, a diagnostic data file name can be given to -grid argument. Test runs for plotting examples are:
 
 python ice.plot.py -grid ocean_geometry.nc -data cic.socagodas.an.2011-10-*T12:00:00Z.nc -figs_path ./fcst -var hice aice
 
@@ -34,4 +34,4 @@ python sfc.time.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_
 
 -figs_path (optional): path to save png files (e.g., -figs_path ./fcst)
 
-By default, scripts save png figures along with data files: time_mean sub-directory for time-average/time-series figures.
+If -fig_path is not given, scripts will save png figures along with data files.

--- a/src/mom6-tools.plot/README.md
+++ b/src/mom6-tools.plot/README.md
@@ -4,7 +4,7 @@
 
 offline.plot.sh path_for_case1 path_for_case2
 
-If multiple case path inputs are given, the script will go through loops to create figure directories for each run of cases. In $RUNCDATE/Figures, sea ice fraction, SST, SSH, and time_mean figures will be created. Detail instruction to run plotting python scripts are given below:
+If multiple case path inputs are given, the script will go through loops to create figure directories for each run of cases. In $RUNCDATE/Figures, sea ice fraction, SST, SSH, and time_mean figures will be created. Detail instruction to run plotting python scripts is given below:
 
 0-2-1. Python scripts require two input arguments: grid and data file names. Multiple data files can be used with wildcard (*) input for data file names. As of now (01/07/2020), diag_table files are not fully updated for variables needed in mom6-tools modules yet. For the time being, users can utilize ocean_geometry.nc in /scratch2/NCEPDEV/marineda/common. Test runs for plotting examples are:
 

--- a/src/mom6-tools.plot/README.md
+++ b/src/mom6-tools.plot/README.md
@@ -1,6 +1,12 @@
 0-1. This directory contains python plotting scripts based on mom6-tools. Note that scripts run with local cartopy shapefiles in /scratch2/NCEPDEV/marineda/common/cartopy.
 
-0-2. Python scripts require two input arguments: grid and data file names. Multiple data files can be used with wildcard (*) input for data file names. As of now (01/07/2020), diag_table files are not fully updated for variables needed in mom6-tools modules yet. For the time being, users can utilize ocean_geometry.nc in /scratch2/NCEPDEV/marineda/common. Test runs for plotting examples are:
+0-2. offline.plot.sh can be used to generate post processing plots. This script can be copied to any local directory and run with input path of each case (or path of PROJECT_DIR/WORKFLOW_NAME):
+
+offline.plot.sh path_for_case1 path_for_case2
+
+If multiple case path inputs are given, the script will go through loops to create figure directories for each run of cases. In $RUNCDATE/Figures, sea ice fraction, SST, SSH, and time_mean figures will be created. Detail instruction to run plotting python scripts are given below:
+
+0-2-1. Python scripts require two input arguments: grid and data file names. Multiple data files can be used with wildcard (*) input for data file names. As of now (01/07/2020), diag_table files are not fully updated for variables needed in mom6-tools modules yet. For the time being, users can utilize ocean_geometry.nc in /scratch2/NCEPDEV/marineda/common. Test runs for plotting examples are:
 
 python ice.plot.py -grid ocean_geometry.nc -data cic.socagodas.an.2011-10-*T12:00:00Z.nc -figs_path ./fcst -var hice aice
 

--- a/src/mom6-tools.plot/README.md
+++ b/src/mom6-tools.plot/README.md
@@ -4,7 +4,7 @@
 
 offline.plot.sh path_for_case1 path_for_case2
 
-If multiple case path inputs are given, the script will go through loops to create figure directories for each run of cases. In $RUNCDATE/Figures, sea ice fraction, SST, SSH, and time_mean figures will be created. Detail instruction to run plotting python scripts is given below:
+If multiple case path inputs are given, the script will go through loops to create figure directories for each run of cases. In $RUNCDATE/Figures, sea ice fraction, SST, SSH, and time_mean figures will be created. Detail instruction to run each plotting python script is given below:
 
 0-2-1. Python scripts require two input arguments: grid and data file names. Multiple data files can be used with wildcard (*) input for data file names. As of now (01/07/2020), diag_table files are not fully updated for variables needed in mom6-tools modules yet. For the time being, users can utilize ocean_geometry.nc in /scratch2/NCEPDEV/marineda/common. Test runs for plotting examples are:
 

--- a/src/mom6-tools.plot/ice.plot.py
+++ b/src/mom6-tools.plot/ice.plot.py
@@ -58,6 +58,7 @@ for filename in args.data:
         ice_nh = np.ma.masked_where(grd.geolat < 0., ice[0,:,:])    
 
         path_ = Path(filename)
+        name_ = Path(filename).name
         if args.figs_path is None:
             file_ice_nh = str(path_.parent.joinpath(path_.stem + '_'+var+'_nh.png'))
             file_ice_sh = str(path_.parent.joinpath(path_.stem + '_'+var+'_sh.png'))
@@ -65,7 +66,7 @@ for filename in args.data:
             file_ice_nh = str(args.figs_path+'/'+path_.stem + '_'+var+'_nh.png')
             file_ice_sh = str(args.figs_path+'/'+path_.stem + '_'+var+'_sh.png')
 
-        title_ice=var+':'+str(path_.parent.joinpath(path_.stem))
+        title_ice=var+':'+str(name_)
 
         if var == 'hice' or var == 'hi_h': clim_ = clim_hice
         if var == 'aice' or var == 'aice_h': clim_ = clim_aice

--- a/src/mom6-tools.plot/ice.plot.py
+++ b/src/mom6-tools.plot/ice.plot.py
@@ -47,7 +47,6 @@ else:
     vars_ = args.var
 
 grd= MOM6grid(args.grid)
-grd.area_t= grd.Ah
 
 clmap_=cmocean.cm.ice
 

--- a/src/mom6-tools.plot/offline.plot.sh
+++ b/src/mom6-tools.plot/offline.plot.sh
@@ -1,28 +1,37 @@
 #!/bin/bash
 
-#1. set CLONE_DIR and RUN_DIR/PROJECT_NAME containing data files to plot
-export CLONE_DIR=/scratch2/NCEPDEV/marineda/Jong.Kim/godas_wk
-export RUN_DIR=/scratch1/NCEPDEV/stmp2/Jong.Kim/Jong.Kim/rundir
-export PROJECT_NAME=workflow_diag
+CASES_NUM=$#
+#0. check number of input cases
+if [ $CASES_NUM -lt 1 ]; then
+        echo "Path for project name is empty: ./offline.plot.sh path_for_case1 ..."
+        exit 0
+fi
 
-#2. png files: saved in Figures directory of $RUNCDATE/Figures
-export SOCA_EXEC=$CLONE_DIR/build/bin
-export MOD_PATH=$CLONE_DIR/modulefiles
-export ROOT_GODAS_DIR=$CLONE_DIR
-dirs=$(ls $RUN_DIR/$PROJECT_NAME)
+for i in "$@"; do
+  CASE_PATH=$i
+  echo "Creating post processing plots for case: $CASE_PATH"
 
-for f in $dirs; do
-    if [ -d $RUN_DIR/$PROJECT_NAME/${f} ]; then
-	if [[ $f =~ "19" || $f =~ "20" ]]; then
-            export CDATE=$f
-	    echo $CDATE
-	    export RUNCDATE=$RUN_DIR/$PROJECT_NAME/$CDATE
-	    export FiguresDir=$RUNCDATE/Figures
-	    export IceAnlDir=$RUN_DIR/$PROJECT_NAME/$CDATE/Data
-	    export OceanFcstDir=$RUN_DIR/$PROJECT_NAME/$CDATE/fcst
+  #1. set PATHs for case to make plots
+  if [ -f $CASE_PATH/config.base ]; then
+      source $CASE_PATH/config.base
 
-	    source $MOD_PATH/godas.python
-	    source $CLONE_DIR/scripts/post_plot.sh
-	fi
-    fi
+      #2. png files: saved in Figures directory of $RUNCDATE/Figures
+      dirs=$(ls $RUNDIR |  grep '^[0-9]*$' )
+
+      for f in $dirs; do
+	  if [ -d $RUNDIR/${f} ]; then
+              export CDATE=$f
+	      echo $CDATE
+	      export RUNCDATE=$RUNDIR/$CDATE
+	      export FiguresDir=$RUNCDATE/Figures
+	      export IceAnlDir=$RUNDIR/$CDATE/Data
+	      export OceanFcstDir=$RUNDIR/$CDATE/fcst
+
+	      source $MOD_PATH/godas.python
+	      source $ROOT_GODAS_DIR/scripts/post_plot.sh
+	  fi
+      done
+  else
+      echo 'config.base does not exists: '$CASE_PATH
+  fi
 done

--- a/src/mom6-tools.plot/offline.plot.sh
+++ b/src/mom6-tools.plot/offline.plot.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#1. set CLONE_DIR and RUN_DIR/PROJECT_NAME containing data files to plot
+export CLONE_DIR=/scratch2/NCEPDEV/marineda/Jong.Kim/godas_wk
+export RUN_DIR=/scratch1/NCEPDEV/stmp2/Jong.Kim/Jong.Kim/rundir
+export PROJECT_NAME=workflow_diag
+
+#2. png files: saved in Figures directory of $RUNCDATE/Figures
+export SOCA_EXEC=$CLONE_DIR/build/bin
+export MOD_PATH=$CLONE_DIR/modulefiles
+export ROOT_GODAS_DIR=$CLONE_DIR
+dirs=$(ls $RUN_DIR/$PROJECT_NAME)
+
+for f in $dirs; do
+    if [ -d $RUN_DIR/$PROJECT_NAME/${f} ]; then
+	if [[ $f =~ "19" || $f =~ "20" ]]; then
+            export CDATE=$f
+	    echo $CDATE
+	    export RUNCDATE=$RUN_DIR/$PROJECT_NAME/$CDATE
+	    export FiguresDir=$RUNCDATE/Figures
+	    export IceAnlDir=$RUN_DIR/$PROJECT_NAME/$CDATE/Data
+	    export OceanFcstDir=$RUN_DIR/$PROJECT_NAME/$CDATE/fcst
+
+	    source $MOD_PATH/godas.python
+	    source $CLONE_DIR/scripts/post_plot.sh
+	fi
+    fi
+done

--- a/src/mom6-tools.plot/sfc.plot.py
+++ b/src/mom6-tools.plot/sfc.plot.py
@@ -29,7 +29,6 @@ else:
     if not os.path.isdir(args.figs_path): os.makedirs(args.figs_path)
 
 grd= MOM6grid(args.grid)
-grd.area_t=grd.Ah
 
 clim_sst=[-2,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32]
 clim_ssh=[-1.5,-1.0,-0.5,0.0,0.5,1.0,1.5,2.0]

--- a/src/mom6-tools.plot/sfc.plot.py
+++ b/src/mom6-tools.plot/sfc.plot.py
@@ -36,6 +36,7 @@ clim_ssh=[-1.5,-1.0,-0.5,0.0,0.5,1.0,1.5,2.0]
 for filename in args.data:
     nc = xr.open_mfdataset(filename , decode_times=False)
     path_ = Path(filename)
+    name_ = Path(filename).name
     if args.figs_path is None:
       sst_fig = str(path_.parent.joinpath(path_.stem + '_SST.png'))
       ssh_fig = str(path_.parent.joinpath(path_.stem + '_SSH.png'))
@@ -43,8 +44,8 @@ for filename in args.data:
       sst_fig = str(args.figs_path+'/'+path_.stem + '_SST.png')
       ssh_fig = str(args.figs_path+'/'+path_.stem + '_SSH.png')
 
-    title_sst='SST:'+str(path_.parent.joinpath(path_.stem))
-    title_ssh='SSH:'+str(path_.parent.joinpath(path_.stem))
+    title_sst='SST:'+str(name_)
+    title_ssh='SSH:'+str(name_)
 
     xyplot(nc.SST[0,:,:].to_masked_array(),grd.geolon,grd.geolat,clim=clim_sst,title=title_sst,save=sst_fig)
     xyplot(nc.SSU[0,:,:].to_masked_array(),grd.geolon,grd.geolat,clim=clim_ssh,title=title_ssh,save=ssh_fig)

--- a/src/mom6-tools.plot/sfc.time.plot.py
+++ b/src/mom6-tools.plot/sfc.time.plot.py
@@ -90,7 +90,6 @@ if __name__ == "__main__":
 
   # load mom6 grid
   grd = MOM6grid(args.grid)
-  grd.area_t = grd.Ah
 
   # set data and fig file path 
   if args.figs_path is None:

--- a/workflow/cases/fcst_only.yaml
+++ b/workflow/cases/fcst_only.yaml
@@ -7,8 +7,8 @@ case:
     FCSTMODEL: MOM6CICE5 # MOM6solo
   
   da_settings:
-    NO_ENS_MBR: 2
-    GROUPS: 2
+    NO_ENS_MBR: 1
+    GROUPS: 1
   
   places:
     workflow_file: layout/fcst_only.yaml

--- a/workflow/cases/fcst_only.yaml
+++ b/workflow/cases/fcst_only.yaml
@@ -7,8 +7,8 @@ case:
     FCSTMODEL: MOM6CICE5 # MOM6solo
   
   da_settings:
-    NO_ENS_MBR: 1
-    GROUPS: 1
+    NO_ENS_MBR: 2
+    GROUPS: 2
   
   places:
     workflow_file: layout/fcst_only.yaml

--- a/workflow/defaults/places.yaml
+++ b/workflow/defaults/places.yaml
@@ -24,3 +24,4 @@ default_places: &default_places
   SHORT_TERM_TEMP: !calc doc.platform.short_term_temp             # short term storage
   LONG_TERM_TEMP:  !calc doc.platform.long_term_temp              # long term storage
   RUNDIR: !expand "{LONG_TERM_TEMP}/{tools.env('USER')}/rundir/{doc.names.experiment}" # RUN directory
+  FIG_DIR: !expand "{LONG_TERM_TEMP}/{tools.env('USER')}/rundir/{doc.names.experiment}/Figures" # Figure directory

--- a/workflow/layout/3dvar_only.yaml
+++ b/workflow/layout/3dvar_only.yaml
@@ -47,7 +47,7 @@ suite: !Cycle
         <<: *shared_task_template
         Trigger: !Depend  fcst_run
         resources: !calc partition.resources.run_fcst_prep
-        rocoto_command: "echo post"
+#        rocoto_command: "echo post"
         config: [ base ]
         J_JOB: JJOB_POST
 

--- a/workflow/layout/3dvar_only.yaml
+++ b/workflow/layout/3dvar_only.yaml
@@ -47,7 +47,6 @@ suite: !Cycle
         <<: *shared_task_template
         Trigger: !Depend  fcst_run
         resources: !calc partition.resources.run_fcst_prep
-#        rocoto_command: "echo post"
         config: [ base ]
         J_JOB: JJOB_POST
 

--- a/workflow/layout/fcst_only.yaml
+++ b/workflow/layout/fcst_only.yaml
@@ -45,7 +45,6 @@ suite: !Cycle
         <<: *shared_task_template
         Trigger: !Depend  fcst_run
         resources: !calc partition.resources.run_fcst
-#        rocoto_command: "echo post"
         config: [ base ]
         J_JOB: JJOB_POST
 

--- a/workflow/layout/fcst_only.yaml
+++ b/workflow/layout/fcst_only.yaml
@@ -44,7 +44,7 @@ suite: !Cycle
       post: !Task
         <<: *shared_task_template
         Trigger: !Depend  fcst_run
-        resources: !calc partition.resources.run_nothing
+        resources: !calc partition.resources.run_fcst
 #        rocoto_command: "echo post"
         config: [ base ]
         J_JOB: JJOB_POST


### PR DESCRIPTION
## Description
1. diag_table_template  inside scripts/templates directory is updated with additional diagnostic variables needed for use of mom6-tools 
2. Updated post_plot.sh to run inside workflow. But due to memory management issue on hera, the line to call this script in JJOB_POST is commented out at this time. As an alternative and offline use,  offline.plot.sh is added to create plotting figures n Figures directory. Instruction to run the script is given in README

## Testing
After experiment run finishes, diagnostic plotting figures can be created with offline.plot.sh (available at src/mom6-tools). The script can be copied to any local directory and run with input path of PROJECT_DIR/WORKFLOW_NAME

For an example run:
./offline.plot.sh /scratch2/NCEPDEV/marineda/Jong.Kim/scrub/sandbox/tools_run

Note: multiple path inputs of PROJECT_DIR/WORKFLOW_NAME can be used. The script will go through loop of given path inputs.
./offline.plot.sh workflow_name_path1 workflow_name_path2



