### PR TITLE
Vertical cross section (zonal and meridional) and Salinity field to mom6tools plotting package

### DIFF
--- a/scripts/post_plot.sh
+++ b/scripts/post_plot.sh
@@ -38,10 +38,17 @@ if [ -e "${files2plot[0]}" ]; then
 	   -grid $GridFile                           \
 	   -data $OceanFcstDir/ocn_*.nc              \
 	   -figs_path $FiguresDir 
+    # 2a. meridional cross section
     ipython -- $SOCA_EXEC/yz.plot.py                    \
 	   -grid $GridFile                           \
 	   -data $OceanFcstDir/ocn_*.nc              \
+	   -figs_path $FiguresDir
+    # 2b. zonal cross section
+    ipython -- $SOCA_EXEC/xz.plot.py                    \
+	   -grid $GridFile                           \
+	   -data $OceanFcstDir/ocn_*.nc              \
 	   -figs_path $FiguresDir 
+ 
 fi
 
 # 3. Plot time averages

--- a/scripts/post_plot.sh
+++ b/scripts/post_plot.sh
@@ -38,6 +38,10 @@ if [ -e "${files2plot[0]}" ]; then
 	   -grid $GridFile                           \
 	   -data $OceanFcstDir/ocn_*.nc              \
 	   -figs_path $FiguresDir 
+    ipython -- $SOCA_EXEC/yz.plot.py                    \
+	   -grid $GridFile                           \
+	   -data $OceanFcstDir/ocn_*.nc              \
+	   -figs_path $FiguresDir 
 fi
 
 # 3. Plot time averages

--- a/src/mom6-tools.plot/README.md
+++ b/src/mom6-tools.plot/README.md
@@ -8,7 +8,7 @@ If multiple case path inputs are given, the script will go through loops to crea
 
 0-2-1. Python plotting scripts of mom6-tools require two input arguments: grid and data file names. Multiple data files can be used with wildcard (*) input for data file names. We keep -grid argument to allow fexibility of using any source of geolon/geolat information. If diagnostic data files contain geolon/geolat variables, a diagnostic data file name can be given to -grid argument. Test runs for plotting examples are:
 
-*python ice.plot.py -grid ocean_geometry.nc -data cic.socagodas.an.2011-10-*T12:00:00Z.nc -figs_path ./fcst -var hice aice*
+* python ice.plot.py -grid ocean_geometry.nc -data cic.socagodas.an.2011-10-*T12:00:00Z.nc -figs_path ./fcst -var hice aice 
 
 -grid file: geometry input file should contain geolon and geolat variables.
 
@@ -18,7 +18,7 @@ If multiple case path inputs are given, the script will go through loops to crea
 
 -var (optional): variable names to plot (e.g., -var hice aice or -var hi_h aice_h)
 
-*python sfc.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./fcst*
+* python sfc.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./fcst*
 
 -grid file: geometry input file should contain geolon and geolat variables.
 
@@ -26,7 +26,7 @@ If multiple case path inputs are given, the script will go through loops to crea
 
 -figs_path (optional): path to save png files (e.g., -figs_path ./fcst)
 
-*python sfc.time.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./time_mean*
+* python sfc.time.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./time_mean*
 
 -grid file: geometry input file should contain geolon and geolat variables.
 
@@ -34,7 +34,7 @@ If multiple case path inputs are given, the script will go through loops to crea
 
 -figs_path (optional): path to save png files (e.g., -figs_path ./fcst)
 
-*python x(or y)z.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./time_mean*
+* python x(or y)z.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./time_mean*
 
 -grid file: geometry input file should contain geolon and geolat variables.
 

--- a/src/mom6-tools.plot/README.md
+++ b/src/mom6-tools.plot/README.md
@@ -8,7 +8,7 @@ If multiple case path inputs are given, the script will go through loops to crea
 
 0-2-1. Python plotting scripts of mom6-tools require two input arguments: grid and data file names. Multiple data files can be used with wildcard (*) input for data file names. We keep -grid argument to allow fexibility of using any source of geolon/geolat information. If diagnostic data files contain geolon/geolat variables, a diagnostic data file name can be given to -grid argument. Test runs for plotting examples are:
 
-python ice.plot.py -grid ocean_geometry.nc -data cic.socagodas.an.2011-10-*T12:00:00Z.nc -figs_path ./fcst -var hice aice
+*python ice.plot.py -grid ocean_geometry.nc -data cic.socagodas.an.2011-10-*T12:00:00Z.nc -figs_path ./fcst -var hice aice*
 
 -grid file: geometry input file should contain geolon and geolat variables.
 
@@ -18,7 +18,7 @@ python ice.plot.py -grid ocean_geometry.nc -data cic.socagodas.an.2011-10-*T12:0
 
 -var (optional): variable names to plot (e.g., -var hice aice or -var hi_h aice_h)
 
-python sfc.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./fcst
+*python sfc.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./fcst*
 
 -grid file: geometry input file should contain geolon and geolat variables.
 
@@ -26,7 +26,7 @@ python sfc.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path 
 
 -figs_path (optional): path to save png files (e.g., -figs_path ./fcst)
 
-python sfc.time.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./time_mean
+*python sfc.time.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./time_mean*
 
 -grid file: geometry input file should contain geolon and geolat variables.
 
@@ -34,4 +34,16 @@ python sfc.time.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_
 
 -figs_path (optional): path to save png files (e.g., -figs_path ./fcst)
 
+*python x(or y)z.plot.py -grid ocean_geometry.nc -data ocn_2012_01_*_03.nc -figs_path ./time_mean*
+
+-grid file: geometry input file should contain geolon and geolat variables.
+
+-data file: temp and so variables are used to make cross-sections at specific longitudes and latitudes,
+and down to 500m depth, these options are hardcoded in the scripts.
+
+-figs_path (optional): path to save png files (e.g., -figs_path ./fcst)
+
+
 If -fig_path is not given, scripts will save png figures along with data files.
+
+

--- a/src/mom6-tools.plot/plot_func.py
+++ b/src/mom6-tools.plot/plot_func.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python3
+
+def SOCAgrd_Lon (lon):
+    if lon > 60:
+       lon = lon - 360 
+    else:
+       lon = lon
+
+#    print (lon)
+    return lon 

--- a/src/mom6-tools.plot/plot_func.py
+++ b/src/mom6-tools.plot/plot_func.py
@@ -2,9 +2,8 @@
 
 def SOCAgrd_Lon (lon):
     if lon > 60:
-       lon = lon - 360 
+       lon = lon - 360
     else:
        lon = lon
 
-#    print (lon)
-    return lon 
+    return lon

--- a/src/mom6-tools.plot/sfc.plot.py
+++ b/src/mom6-tools.plot/sfc.plot.py
@@ -32,6 +32,7 @@ grd= MOM6grid(args.grid)
 
 clim_sst=[-2,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32]
 clim_ssh=[-1.5,-1.0,-0.5,0.0,0.5,1.0,1.5,2.0]
+clim_sss=[30,31,32,33,34,35,36,37,38,39,40]
 
 for filename in args.data:
     nc = xr.open_mfdataset(filename , decode_times=False)
@@ -40,13 +41,18 @@ for filename in args.data:
     if args.figs_path is None:
       sst_fig = str(path_.parent.joinpath(path_.stem + '_SST.png'))
       ssh_fig = str(path_.parent.joinpath(path_.stem + '_SSH.png'))
+      sss_fig = str(path_.parent.joinpath(path_.stem + '_SSS.png'))
+
     else:
       sst_fig = str(args.figs_path+'/'+path_.stem + '_SST.png')
       ssh_fig = str(args.figs_path+'/'+path_.stem + '_SSH.png')
+      sss_fig = str(args.figs_path+'/'+path_.stem + '_SSS.png')
 
     title_sst='SST:'+str(name_)
     title_ssh='SSH:'+str(name_)
+    title_sss='SSS:'+str(name_)
 
     xyplot(nc.SST[0,:,:].to_masked_array(),grd.geolon,grd.geolat,clim=clim_sst,title=title_sst,save=sst_fig)
-    xyplot(nc.SSU[0,:,:].to_masked_array(),grd.geolon,grd.geolat,clim=clim_ssh,title=title_ssh,save=ssh_fig)
-  
+    xyplot(nc.SSH[0,:,:].to_masked_array(),grd.geolon,grd.geolat,clim=clim_ssh,title=title_ssh,save=ssh_fig)
+    xyplot(nc.SSS[0,:,:].to_masked_array(),grd.geolon,grd.geolat,clim=clim_sss,title=title_sss,save=sss_fig)
+   

--- a/src/mom6-tools.plot/xz.plot.py
+++ b/src/mom6-tools.plot/xz.plot.py
@@ -37,6 +37,8 @@ clim_sst=[-2,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32]
 clim_ssh=[-1.5,-1.0,-0.5,0.0,0.5,1.0,1.5,2.0]
 clim_sss=[30,31,32,33,34,35,36,37,38,39,40]
 
+depth_max=500
+
 cross_location_latitude = [-50, -30, 0, 30, 50] 
 for filename in args.data:
     for crs_loc_lat in cross_location_latitude:
@@ -61,6 +63,11 @@ for filename in args.data:
            sal_fig = str(args.figs_path+'/'+path_.stem + '_sal_' + FigFileName + '.png')
            title_cross_sal='Sea Water Salinity (psu at ' + FigFileName + '):' +str(name_)
 
+#TODO: Make the depth selection elegant
+        ind_depth=np.where(nc.z_l<=depth_max)
 
-        yzplot(nc.temp[0,:,yh_cross,:].to_masked_array(), grd.xh, -grd.z_l, plotype='contourf', clim=clim_sst,title=title_cross_temp,save=temp_fig)
-        yzplot(nc.so[0,:,yh_cross,:].to_masked_array(), grd.xh, -grd.z_l, plotype='contourf', clim=clim_sss,title=title_cross_sal,save=sal_fig)
+        yzplot(nc.temp[0,np.min(ind_depth):np.max(ind_depth)+1, yh_cross,:].to_masked_array(), grd.xh, -grd.z_l[ind_depth], plotype='contourf', clim=clim_sst,title=title_cross_temp,save=temp_fig)
+
+        yzplot(nc.so[0,np.min(ind_depth):np.max(ind_depth)+1,yh_cross,:].to_masked_array(), grd.xh, -grd.z_[ind_depth]l, plotype='contourf', clim=clim_sss,title=title_cross_sal,save=sal_fig)
+        
+        plt.close('all')

--- a/src/mom6-tools.plot/xz.plot.py
+++ b/src/mom6-tools.plot/xz.plot.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from mom6_tools.MOM6grid import MOM6grid
 from mom6_tools.latlon_analysis import time_mean_latlon
 from mom6_tools.m6plot import xyplot, yzplot
-from plot_func import SOCAgrd_Lon
 import matplotlib.pyplot as plt
 import warnings
 import xarray as xr
@@ -36,19 +35,17 @@ grd= MOM6grid(args.grid)
 clim_sst=[-2,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32]
 clim_ssh=[-1.5,-1.0,-0.5,0.0,0.5,1.0,1.5,2.0]
 
-cross_location_longitude = [ -155, -125, -35, -25, 165, 90, 60] 
+cross_location_latitude = [-50, -30, 0, 30, 50] 
 for filename in args.data:
-    for crs_loc_lon in cross_location_longitude:
-        crs_loc_lon_adj = SOCAgrd_Lon (crs_loc_lon)
-        print ("Cross Location Longitude=" + str(crs_loc_lon_adj))
-        xh_cross = np.argmin(np.abs(grd.xh-crs_loc_lon_adj))
+    for crs_loc_lat in cross_location_latitude:
+        yh_cross = np.argmin(np.abs(grd.yh-crs_loc_lat))
         nc = xr.open_mfdataset(filename , decode_times=False)
         path_ = Path(filename)
         name_ = Path(filename).name
-        if crs_loc_lon < 0:
-           FigFileName = str(abs(crs_loc_lon)) + 'W'
+        if crs_loc_lat < 0:
+           FigFileName = str(abs(crs_loc_lat)) + 'S'
         else:
-           FigFileName = str(abs(crs_loc_lon)) + 'E'
+           FigFileName = str(abs(crs_loc_lat)) + 'N'
 
         if args.figs_path is None:
            file_fig = str(args.figs_path+'/'+path_.stem + '_temp_' + FigFileName + '.png')
@@ -57,4 +54,4 @@ for filename in args.data:
            file_fig = str(args.figs_path+'/'+path_.stem + '_temp_' + FigFileName + '.png')
            title_cross='Potential temp (degC at ' + FigFileName + '):' +str(name_)
 
-        yzplot(nc.temp[0,:,:,xh_cross].to_masked_array(), grd.yh, -grd.z_l, plotype='contourf', clim=clim_sst,title=title_cross,save=file_fig)
+        yzplot(nc.temp[0,:,yh_cross,:].to_masked_array(), grd.xh, -grd.z_l, plotype='contourf', clim=clim_sst,title=title_cross,save=file_fig)

--- a/src/mom6-tools.plot/xz.plot.py
+++ b/src/mom6-tools.plot/xz.plot.py
@@ -20,6 +20,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-grid', required=True, help='grid/geometry filename: ocean_geometry.nc')
 parser.add_argument('-data', nargs='*', type=str, required=True, help='diag data filename(s): ocn_*.nc')
 parser.add_argument('-figs_path',help='path to save png files: ./fcst')
+
 args = parser.parse_args()
 
 #print(f'Loading grid... {args.grid}')
@@ -34,6 +35,7 @@ grd= MOM6grid(args.grid)
 
 clim_sst=[-2,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32]
 clim_ssh=[-1.5,-1.0,-0.5,0.0,0.5,1.0,1.5,2.0]
+clim_sss=[30,31,32,33,34,35,36,37,38,39,40]
 
 cross_location_latitude = [-50, -30, 0, 30, 50] 
 for filename in args.data:
@@ -48,10 +50,17 @@ for filename in args.data:
            FigFileName = str(abs(crs_loc_lat)) + 'N'
 
         if args.figs_path is None:
-           file_fig = str(args.figs_path+'/'+path_.stem + '_temp_' + FigFileName + '.png')
-           title_cross='Potential temp (degC at ' + FigFileName + '):' +str(name_)
-        else:
-           file_fig = str(args.figs_path+'/'+path_.stem + '_temp_' + FigFileName + '.png')
-           title_cross='Potential temp (degC at ' + FigFileName + '):' +str(name_)
+           temp_fig = str(args.figs_path+'/'+path_.stem + '_temp_' + FigFileName + '.png')
+           title_cross_temp='Potential temp (degC at ' + FigFileName + '):' +str(name_)
+           sal_fig = str(args.figs_path+'/'+path_.stem + '_sal_' + FigFileName + '.png')
+           title_cross_sal='Sea Water Salinity (psu at ' + FigFileName + '):' +str(name_)
 
-        yzplot(nc.temp[0,:,yh_cross,:].to_masked_array(), grd.xh, -grd.z_l, plotype='contourf', clim=clim_sst,title=title_cross,save=file_fig)
+        else:
+           temp_fig = str(args.figs_path+'/'+path_.stem + '_temp_' + FigFileName + '.png')
+           title_cross_temp='Potential temp (degC at ' + FigFileName + '):' +str(name_)
+           sal_fig = str(args.figs_path+'/'+path_.stem + '_sal_' + FigFileName + '.png')
+           title_cross_sal='Sea Water Salinity (psu at ' + FigFileName + '):' +str(name_)
+
+
+        yzplot(nc.temp[0,:,yh_cross,:].to_masked_array(), grd.xh, -grd.z_l, plotype='contourf', clim=clim_sst,title=title_cross_temp,save=temp_fig)
+        yzplot(nc.so[0,:,yh_cross,:].to_masked_array(), grd.xh, -grd.z_l, plotype='contourf', clim=clim_sss,title=title_cross_sal,save=sal_fig)

--- a/src/mom6-tools.plot/yz.plot.py
+++ b/src/mom6-tools.plot/yz.plot.py
@@ -1,0 +1,53 @@
+import os, sys
+file_path = '/scratch2/NCEPDEV/marineda/common/mom6-tools/mom6_tools'
+sys.path.append(os.path.dirname(file_path))
+
+from pathlib import Path
+from mom6_tools.MOM6grid import MOM6grid
+from mom6_tools.latlon_analysis import time_mean_latlon
+from mom6_tools.m6plot import xyplot, yzplot
+import matplotlib.pyplot as plt
+import warnings
+import xarray as xr
+import argparse
+import numpy as np
+
+class args:
+  pass
+
+# required arg
+parser = argparse.ArgumentParser()
+parser.add_argument('-grid', required=True, help='grid/geometry filename: ocean_geometry.nc')
+parser.add_argument('-data', nargs='*', type=str, required=True, help='diag data filename(s): ocn_*.nc')
+parser.add_argument('-figs_path',help='path to save png files: ./fcst')
+args = parser.parse_args()
+
+#print(f'Loading grid... {args.grid}')
+#print(f'Loading data... {args.data}')
+
+if args.figs_path is None:
+    print('Creating figures in -data directory ...')
+else:
+    if not os.path.isdir(args.figs_path): os.makedirs(args.figs_path)
+
+grd= MOM6grid(args.grid)
+
+clim_sst=[-2,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32]
+clim_ssh=[-1.5,-1.0,-0.5,0.0,0.5,1.0,1.5,2.0]
+
+cross_location_longitude = -30 #east
+xh_cross = np.argmin(np.abs(grd.xh-cross_location_longitude))
+
+for filename in args.data:
+    nc = xr.open_mfdataset(filename , decode_times=False)
+    path_ = Path(filename)
+    name_ = Path(filename).name
+    if args.figs_path is None:
+      file_fig = str(path_.parent.joinpath(path_.stem + '_temp_30W.png'))
+    else:
+      file_fig = str(args.figs_path+'/'+path_.stem + '_temp_30W.png')
+
+    title_cross='Potential temp (degC at 30W): '+str(name_)
+
+    yzplot(nc.temp[0,:,:,xh_cross].to_masked_array(), grd.yh, -grd.z_l, plotype='contourf', clim=clim_sst,title=title_cross,save=file_fig)
+  

--- a/src/mom6-tools.plot/yz.plot.py
+++ b/src/mom6-tools.plot/yz.plot.py
@@ -37,6 +37,8 @@ clim_sst=[-2,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32]
 clim_ssh=[-1.5,-1.0,-0.5,0.0,0.5,1.0,1.5,2.0]
 clim_sss=[30,31,32,33,34,35,36,37,38,39,40]
 
+depth_max=500
+
 cross_location_longitude = [ -155, -125, -35, -25, 165, 90, 60] 
 for filename in args.data:
     for crs_loc_lon in cross_location_longitude:
@@ -63,6 +65,11 @@ for filename in args.data:
            sal_fig = str(args.figs_path+'/'+path_.stem + '_sal_' + FigFileName + '.png')
            title_cross_sal='Sea Water Salinity (psu at ' + FigFileName + '):' +str(name_)
 
+#TODO: Make the depth selection elegant
+        ind_depth=np.where(nc.z_l<=depth_max)
 
-        yzplot(nc.temp[0,:,:,xh_cross].to_masked_array(), grd.yh, -grd.z_l, plotype='contourf', clim=clim_sst,title=title_cross_temp,save=temp_fig)
-        yzplot(nc.so[0,:,:,xh_cross].to_masked_array(), grd.yh, -grd.z_l, plotype='contourf', clim=clim_sss,title=title_cross_sal,save=sal_fig)
+        yzplot(nc.temp[0,np.min(ind_depth):np.max(ind_depth)+1,:,xh_cross].to_masked_array(), grd.yh, -grd.z_l[ind_depth], plotype='contourf', clim=clim_sst,title=title_cross_temp,save=temp_fig)
+        
+        yzplot(nc.so[0,np.min(ind_depth):np.max(ind_depth)+1,:,xh_cross].to_masked_array(), grd.yh, -grd.z_l[ind_depth], plotype='contourf', clim=clim_sss,title=title_cross_sal,save=sal_fig)
+
+        plt.close('all')

--- a/src/mom6-tools.plot/yz.plot.py
+++ b/src/mom6-tools.plot/yz.plot.py
@@ -35,7 +35,7 @@ grd= MOM6grid(args.grid)
 clim_sst=[-2,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32]
 clim_ssh=[-1.5,-1.0,-0.5,0.0,0.5,1.0,1.5,2.0]
 
-cross_location_longitude = -30 #east
+cross_location_longitude = -30 #west
 xh_cross = np.argmin(np.abs(grd.xh-cross_location_longitude))
 
 for filename in args.data:

--- a/src/mom6-tools.plot/yz.plot.py
+++ b/src/mom6-tools.plot/yz.plot.py
@@ -35,6 +35,7 @@ grd= MOM6grid(args.grid)
 
 clim_sst=[-2,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32]
 clim_ssh=[-1.5,-1.0,-0.5,0.0,0.5,1.0,1.5,2.0]
+clim_sss=[30,31,32,33,34,35,36,37,38,39,40]
 
 cross_location_longitude = [ -155, -125, -35, -25, 165, 90, 60] 
 for filename in args.data:
@@ -51,10 +52,17 @@ for filename in args.data:
            FigFileName = str(abs(crs_loc_lon)) + 'E'
 
         if args.figs_path is None:
-           file_fig = str(args.figs_path+'/'+path_.stem + '_temp_' + FigFileName + '.png')
-           title_cross='Potential temp (degC at ' + FigFileName + '):' +str(name_)
-        else:
-           file_fig = str(args.figs_path+'/'+path_.stem + '_temp_' + FigFileName + '.png')
-           title_cross='Potential temp (degC at ' + FigFileName + '):' +str(name_)
+           temp_fig = str(args.figs_path+'/'+path_.stem + '_temp_' + FigFileName + '.png')
+           title_cross_temp='Potential temp (degC at ' + FigFileName + '):' +str(name_)
+           sal_fig = str(args.figs_path+'/'+path_.stem + '_sal_' + FigFileName + '.png')
+           title_cross_sal='Sea Water Salinity (psu at ' + FigFileName + '):' +str(name_)
 
-        yzplot(nc.temp[0,:,:,xh_cross].to_masked_array(), grd.yh, -grd.z_l, plotype='contourf', clim=clim_sst,title=title_cross,save=file_fig)
+        else:
+           temp_fig = str(args.figs_path+'/'+path_.stem + '_temp_' + FigFileName + '.png')
+           title_cross_temp='Potential temp (degC at ' + FigFileName + '):' +str(name_)
+           sal_fig = str(args.figs_path+'/'+path_.stem + '_sal_' + FigFileName + '.png')
+           title_cross_sal='Sea Water Salinity (psu at ' + FigFileName + '):' +str(name_)
+
+
+        yzplot(nc.temp[0,:,:,xh_cross].to_masked_array(), grd.yh, -grd.z_l, plotype='contourf', clim=clim_sst,title=title_cross_temp,save=temp_fig)
+        yzplot(nc.so[0,:,:,xh_cross].to_masked_array(), grd.yh, -grd.z_l, plotype='contourf', clim=clim_sss,title=title_cross_sal,save=sal_fig)


### PR DESCRIPTION
## Description
This PR extends the mom6-tools suite of plotting scripts with the addition of:
0. vertical cross-section plots for
    0a. Zonal/Latitudinal (5 plots per per field fcst file)
    0b. Meridional/Longitudinal (7 plots per field per fcst file)
1. Addition of salinity field to surface and vertical cross-section plotting scripts.
2. Bug fix for SSH in sfc.plot.py script. Earlier version was using SSU field instead of SSH.

Is a change of answers expected from this PR?
Yes, in SSH plots.

**Note: The originator of these scripts is Dr. Jong Kim.**

###  Issue(s) addressed
- fixes #153
- fixes #154

## Testing
Test by running the 3dvar.yaml case through workflow for a day.