### PR TITLE
Update of required modules (intel18 and 19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ During this process, three directories will be created:
    `cd $CLONE_DIR/build`
 2. Load the JEDI modules \
    `module purge` \
-   `source  $CLONE_DIR/modulefiles/godas.main` \ 
+   `source  $CLONE_DIR/modulefiles/hera.intel18` \
+   `source  $CLONE_DIR/modulefiles/hera.setenv` \
    `module list` 
 3. Clone all the necessary repositories to build soca \
    `ecbuild --build=release -DMPIEXEC=$MPIEXEC -DMPIEXEC_EXECUTABLE=$MPIEXEC -DBUILD_ECKIT=YES ../src/soca-bundle`

--- a/modulefiles/godas.main
+++ b/modulefiles/godas.main
@@ -1,1 +1,1 @@
-hera.intel19
+hera.intel18

--- a/modulefiles/hera.intel18
+++ b/modulefiles/hera.intel18
@@ -1,23 +1,8 @@
 #%Module######################################################################
+##      GODAS prerequisites
+##
 
-module load intel
-module load impi
-module load szip
-module load hdf5parallel/1.10.5
-module load netcdf-hdf5parallel
-module load pnetcdf
-module load nccmp/1.8.5
-module use -a /contrib/modulefiles
-module load cmake/3.9.0
-module use -a /contrib/da/modulefiles
-module load ecbuild/2.9.0
-module load eigen/3.3.5
-module load boost/1.67-intel-18.0.1.163
+module use /scratch1/NCEPDEV/jcsda/Ryan.Honeyager/jedi/modules
+module load jedi-stack/intel-impi-18.0.5
+module load nco/4.9.1
 
-module list
-
-setenv FC          mpiifort
-setenv CC          mpiicc
-setenv CXX         mpiicpc
-setenv MPIEXEC     /apps/intel/compilers_and_libraries_2017/linux/mpi/intel64/bin/mpirun
-setenv NETCDF_ROOT /apps/netcdf/4.7.0/intel/18.0.5.274/impi/2018.0.4 

--- a/modulefiles/hera.intel19
+++ b/modulefiles/hera.intel19
@@ -1,9 +1,8 @@
 #%Module######################################################################
-##
 ##      GODAS prerequisites
 ##
 
-module use -a /scratch1/NCEPDEV/da/Daniel.Holdaway/opt/modulefiles
-module load apps/jedi/intel-19.0.5.281
-module load nco
+module use /scratch1/NCEPDEV/jcsda/Ryan.Honeyager/jedi/modules
+module load apps/jedi/intel-19.0.5
+module load nco/4.9.1
 

--- a/modulefiles/hera.setenv
+++ b/modulefiles/hera.setenv
@@ -1,0 +1,5 @@
+setenv FC          mpiifort
+setenv CC          mpiicc
+setenv CXX         mpiicpc
+setenv MPIEXEC     /apps/intel/compilers_and_libraries_2017/linux/mpi/intel64/bin/mpirun
+setenv NETCDF_ROOT /apps/netcdf/4.7.0/intel/18.0.5.274/impi/2018.0.4 

--- a/test/test.setup_godas.py
+++ b/test/test.setup_godas.py
@@ -123,9 +123,9 @@ if __name__ == '__main__':
         make_dir(build_dir); os.chdir(build_dir)
 
         if BUILD_COMPILER.strip() is 'intel-19':
-            subprocess.check_call(['bash','-c','module purge; source ../modulefiles/godas.main; module list; ecbuild --build=release -DMPIEXEC=$MPIEXEC -DMPIEXEC_EXECUTABLE=$MPIEXEC -DBUILD_ECKIT=YES -DBUILD_CRTM=OFF ../src/soca-bundle; make -j12'])
+            subprocess.check_call(['csh','-c','module purge; source ../modulefiles/hera.inter19; source ../modulefiles/hera.setenv module list; ecbuild --build=release -DMPIEXEC=$MPIEXEC -DMPIEXEC_EXECUTABLE=$MPIEXEC -DBUILD_ECKIT=YES -DBUILD_CRTM=OFF ../src/soca-bundle; make -j12'])
         else:     #build with intel-18
-            subprocess.check_call(['csh','-c','module purge; source ../modulefiles/hera.intel18; module list; ecbuild --build=release -DMPIEXEC=$MPIEXEC -DMPIEXEC_EXECUTABLE=$MPIEXEC -DBUILD_ECKIT=YES -DBUILD_CRTM=OFF ../src/soca-bundle; make -j12'])
+            subprocess.check_call(['csh','-c','module purge; source ../modulefiles/hera.intel18; source ../modulefiles/hera.setenv module list; ecbuild --build=release -DMPIEXEC=$MPIEXEC -DMPIEXEC_EXECUTABLE=$MPIEXEC -DBUILD_ECKIT=YES -DBUILD_CRTM=OFF ../src/soca-bundle; make -j12'])
 
         soca_config_path=CLONE_DIR+'/src/soca-bundle/soca-config'
         os.chdir(soca_config_path)


### PR DESCRIPTION
## Description

After the last upgrades of the jcsda repositories, the soca could not be compiled.

The module files have been updated with the latest installations of the jedi-stack.

## Testing

Compile the code according to the instructions and run any (all) case.t.)

## Dependencies
There is no
