### PR TITLE
Bugfix: The 025deg analysis at develop is failing

### DIFF
--- a/scripts/prep_forecast.sh
+++ b/scripts/prep_forecast.sh
@@ -409,7 +409,7 @@ mv tmp1 $DATA/datm_data_table
 
 # DATM forcing file name convention is ${DATM_FILENAME_BASE}.$YYYYMMDDHH.nc 
 echo "Link DATM forcing files"
-DATMINPUTDIR="/scratch2/NCEPDEV/marineda/DATM_INPUT/CFSR/${SYEAR}${SMONTH}"
+DATMINPUTDIR="/scratch2/NCEPDEV/marineda/godas_input/DATM_INPUT/CFSR/${SYEAR}${SMONTH}"
 ln -sf ${DATMINPUTDIR}/${DATM_FILENAME_BASE}*.nc $DATA/DATM_INPUT/
 
 ######################################################################

--- a/src/link.sh
+++ b/src/link.sh
@@ -12,7 +12,7 @@ model=${model:-"godas"}
 if [ $model = "godas" ]; then
 
 #if on hera:  (should put on hpss eventually too)
-ln -sf /scratch2/NCEPDEV/marineda/Jessica.Meixner/FIX/* $topdir/../fix/
+ln -sf /scratch2/NCEPDEV/marineda/godas_input/FIX/* $topdir/../fix/
 
 
 fi

--- a/workflow/defaults/places.yaml
+++ b/workflow/defaults/places.yaml
@@ -13,14 +13,13 @@ default_places: &default_places
   EXPDIR :     !expand '{PROJECT_DIR}/{doc.names.experiment}'    # EXPDIR location
   LOG_DIR:     !expand "{EXPDIR}/log"                            # place to logs
   ROTDIR: !expand "{LONG_TERM_TEMP}/comrot/{doc.names.experiment}"   # Rotational directory
-  GODAS_RC:   "/scratch2/NCEPDEV/marine/marineda"                 # Root path for external data
+  GODAS_RC:   "/scratch2/NCEPDEV/marineda/godas_input"                 # Root path for external data
   SOCA_EXEC:   !expand "{ROOT_GODAS_DIR}/build/bin"                # soca-bundle executable path
   SOCA_STATIC: !expand "{GODAS_RC}/soca-static/{doc.da_settings.NI}x{doc.da_settings.NJ}x{doc.da_settings.NK}"
   SOCA_CONFIG:   !expand "{ROOT_GODAS_DIR}/src/soca-bundle/soca-config/emc"             # soca-config path
   DCOM_ROOT: !expand "{GODAS_RC}/ocean_observations/data"         # Observation root path for raw obs
   IODA_ROOT: !expand "{GODAS_RC}/ioda_observations"   # Processed observations
   MOD_PATH: !expand "{ROOT_GODAS_DIR}/modulefiles"
-  MODEL_SCRATCH: "/scratch2/NCEPDEV/ocean/Guillaume.Vernieres/mom6-cice5-fv3/{NI}x{NJ}x{NK}"
   SHORT_TERM_TEMP: !calc doc.platform.short_term_temp             # short term storage
   LONG_TERM_TEMP:  !calc doc.platform.long_term_temp              # long term storage
   RUNDIR: !expand "{LONG_TERM_TEMP}/{tools.env('USER')}/rundir/{doc.names.experiment}" # RUN directory


### PR DESCRIPTION
## Description

1. After the last updates of the soca gridgen, godas was failing due to the naming of the variables at the soca_gridspec.nc from the soca-static. The file was removed and recreated during running. 

2. Took advantage of the situation, and moved all the fix files have been concentrated to one directory:   /scratch2/NCEPDEV/marineda/godas_input

drwxr-sr-x   4 Role.Marineda marineda  4096 Jan 23 14:06 DATM_INPUT
drwxr-sr-x   4 Role.Marineda marineda  4096 Mar 16 01:01 FIX
drwxr-sr-x 125 Role.Marineda marineda 12288 Mar 16 05:04 ioda_observations
drwxr-sr-x   3 Role.Marineda marineda  4096 Mar 16 01:13 ocean_observations
drwxr-sr-x   6 Role.Marineda marineda  4096 Mar 16 00:35 soca-static

And there are softlinks to the old directories, so old intallations do not break.

To test it:
- Clean install of the system, the default 3dvar should go through. 
- Old installations should not have issues, if there are issues, let me know.


