### PR TITLE
Feature/bgc modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
 # Introduction
+Compared to the develop (default) branch, this feature/bgc_modules branch includes source code updates that support the coupled physical-biogeochemical ocean simulation (MOM6-BLING) within the GODAS framework.
+
+BLING (Biogeochemistry with Light, Iron, Nutrients and Gas; Galbraith et al., 2009; Dunne et al., 2020) is a six-tracer biogeochemistry model that includes a simplified representation of steady state phytoplankton and zooplankton dynamics. BLING provides a computationally-light means to simulate large scale patterns in biogeochemical states by adding less than 20% computational costs to the physical simulation in MOM6. BLING is developed at NOAA GFDL and used in GFDL's CM4 contribution to CMIP6. The NOAA-EMC/ocean_BGC repository that includes BLING source code is forked from GFDL's CM4 repository.
+
+References:
+
+Galbraith, E.D. et al. (2010) Regional impacts of iron-light colimitation in a global biogeochemical model. Biogeosciences, 7(3), 1043-1064.
+
+Dunne, J.P. et al. (2020) Simple Global Ocean Biogeochemistry with Light, Iron, Nutrients and Gas version 2 (BLINGv2): Model description and simulation characteristics in GFDL’s CM4.0 (submitted to Journal of Advances in Modeling Earth Systems)
+
 The following five steps will guide you through the process of cloning, building and 
 running the GODAS workflow. 
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Galbraith, E.D. et al. (2010) Regional impacts of iron-light colimitation in a g
 
 Dunne, J.P. et al. (2020) Simple Global Ocean Biogeochemistry with Light, Iron, Nutrients and Gas version 2 (BLINGv2): Model description and simulation characteristics in GFDL’s CM4.0 (submitted to Journal of Advances in Modeling Earth Systems)
 
+---------------------------
 The following five steps will guide you through the process of cloning, building and 
-running the GODAS workflow. 
+running the GODAS workflow with BLING.
 
 During this process, three directories will be created:
 - CLONE_DIR    : The directory where the system is cloned, user defined path

--- a/jobs/JJOB_FCST_PREP
+++ b/jobs/JJOB_FCST_PREP
@@ -20,7 +20,7 @@ case $FCSTMODEL in
       export ENSBEG=$((ENSEND - NMEM_PGRP + 1))
       
       # TODO: Point to better IC'
-      if [ ! -d $RUNCDATE/../NEXT_IC ] & [ "$NO_ENS_MBR" -le "1" ]; then
+      if [ ! -d $RUNCDATE/../NEXT_IC ] && [ "$NO_ENS_MBR" -le "1" ]; then
          nextic=$RUNCDATE/../NEXT_IC
 cat <<EOF
 # Initial Conditions are copied from the static files

--- a/jobs/JJOB_FCST_PREP
+++ b/jobs/JJOB_FCST_PREP
@@ -19,6 +19,8 @@ case $FCSTMODEL in
       export ENSEND=$((NMEM_PGRP * ENSGRP))
       export ENSBEG=$((ENSEND - NMEM_PGRP + 1))
       
+      mkdir -p $RUNCDATE
+
       # TODO: Point to better IC'
       if [ ! -d $RUNCDATE/../NEXT_IC ] && [ "$NO_ENS_MBR" -le "1" ]; then
          nextic=$RUNCDATE/../NEXT_IC

--- a/scripts/prep_forecast.sh
+++ b/scripts/prep_forecast.sh
@@ -84,6 +84,8 @@ DT_DYNAM_MOM6=${DT_DYNAM_MOM6:-"900"}   #MOM6 dynamic time step   [seconds]
 DIAG_TABLE=${DIAG_TABLE:-$TEMPLATEDIR/diag_table_template}
 #input.nml (FMS) 
 MOM6_RESTART_SETTING=${MOM6_RESTART_SETTING:-"r"}  #MOM6 restart setting 'r' or 'n'
+#field_table (for ocean_BGC) X.Liu 03/27/2020 
+FIELD_TABLE=${FIELD_TABLE:-$TEMPLATEDIR/field_table_template}
 
 # CICE5 Ice Variables 
 
@@ -177,7 +179,25 @@ cat > input.nml << EOF
          restart_input_dir = 'INPUT/',
          restart_output_dir = 'MOM6_RESTART/',
          parameter_filename = 'INPUT/MOM_input',
-                              'INPUT/MOM_override' /
+                              'INPUT/MOM_override'
+/
+
+&generic_tracer_nml
+       do_generic_tracer=.true.
+       do_generic_age=.false.
+       do_generic_COBALT=.false.
+       do_generic_BLING=.true.
+       do_generic_miniBLING=.false.
+       do_generic_TOPAZ=.false.
+       force_update_fluxes=.true.
+/
+
+&generic_bling_nml
+      do_carbon=.false.
+      bury_caco3=.false.
+      bury_pop=.false.
+      co2_calc='mocsy'
+/
 EOF
 
 ######################################################################
@@ -193,6 +213,9 @@ MOM6 Forecast
 $SYEAR $SMONTH $SDAY $SHOUR 0 0
 EOF
 cat $DIAG_TABLE >> diag_table
+
+# X.Liu added ocean_BGC registry in field_table 03/27/2020
+cat $FIELD_TABLE >> field_table 
 
 cp $TEMPLATEDIR/data_table.IN $DATA/data_table
 
@@ -295,9 +318,9 @@ mv tmp1 $DATA/INPUT/MOM_input
 
 # TODO: Append to template MOM_override? My (Guillaume) opinion is to keep it empty 
 #       in the static files, and populate it from scratch as needed. 
-#cp $TEMPLATEDIR/MOM_override $DATA/INPUT/MOM_override
-echo 'RESTART_CHECKSUMS_REQUIRED = False' > $DATA/INPUT/MOM_override
-cat $DATA/INPUT/MOM_override
+cp $TEMPLATEDIR/MOM_override $DATA/INPUT/MOM_override # X.Liu uncommented this 03/27/2020
+#echo 'RESTART_CHECKSUMS_REQUIRED = False' > $DATA/INPUT/MOM_override
+#cat $DATA/INPUT/MOM_override
 
 ######################################################################
 # 2.6 CICE input                                                     #

--- a/scripts/templates/MOM_override
+++ b/scripts/templates/MOM_override
@@ -1,4 +1,8 @@
 ! Blank file in which we can put "overrides" for parameters
-!VERBOSITY = 2 
+VERBOSITY = 2
+RESTART_CHECKSUMS_REQUIRED = False
+USE_generic_tracer = True
+TRACERS_MAY_REINIT = True
+CHL_FROM_FILE = False 
 !----------------------------------
 

--- a/scripts/templates/field_table_template
+++ b/scripts/templates/field_table_template
@@ -1,0 +1,171 @@
+### BLING field table 
+## jgj 2013/01/23 updated for BLING
+"namelists","ocean_mod","generic_bling/*global*"
+/
+"namelists","ocean_mod","generic_bling"
+init = f
+ca_2_p = 1.06
+#--------------------------------------------------------------------
+# JGJ 2017/01/31
+# field table entries for initialization of cobalt/bling tracers
+# all unit conversions will be specified in the code based on
+# valid src_var_unit and internal model unit.
+# If field table src_var_unit does not match valid src_var_unit
+# in code, model will give fatal error.
+# valid src_var_units:
+#    NO3, PO4, SiO4    : micromoles_per_liter
+#    O2                : milliliters_per_liter
+#    DIC, ALK          : micromoles_per_kg
+#    all other fields  : none
+# valid src_var_record : 0-12, where 0 is Annual, 1-12 for Jan-Dec
+# 2015/10/05: Use annual data for WOA13 N, P, Si, O2 since monthly data does not extend to depth
+# airsea and ice_ocean fluxes are handled by coupler, so are initialized in COBALT/BLING.
+# 
+# 2015/09/28 jgj updated to provide valid_min, valid_max for tracers to ensure
+# tracers remain positive after interpolation
+# note that values of valid_min and valid_max are in model units not src_units
+# currently only alk, dic and htotal have both a valid_min and valid_max
+# specified in field_table, but valid_max is ignored for now by code.
+# as of 2015/10/06 src_var_record and src_var_gridspec are not yet implemented
+#
+# 2015/10/14 change valid_min for alk and dic to 0 since land values get filled with valid_min
+#            also remove valid_max for alk and dic
+#
+# BLING needs: dic, alk, po4, o2, dop, fed, htotal, co3_ion, irr_mem, biomass_p, chl
+# optional needs: po4_pre, alk_pre, dic_pre, dic_sat, htotal_sat, di14c, do14c
+# dop = srdop in cobalt
+# biomass = phytoplankton biomass = (nlg+nsm+ndi in COBALT) 
+#------------------------------------------------------------------------------------------------
+#
+# O2 from WOA2013  (/archive/mdteam/obs/NOAA-NODC/WOA13/v1.00a/woa13_all_o_annual_01.nc)
+# min = 0, max = 15.44 from input dataset
+# multiply by (1000/22391.6)/1035 to convert from ml/l to mol/kg
+o2_src_file = INPUT/woa13_all_o_annual_01.nc
+o2_src_var_name = o_an
+o2_src_var_unit = milliliters_per_liter
+o2_dest_var_name =  o2
+o2_dest_var_unit = mol kg-1
+o2_src_var_record = 1
+o2_src_var_gridspec = NONE
+o2_valid_min = 0.0
+#
+# PO4 from WOA2013  (/archive/mdteam/obs/NOAA-NODC/WOA13/v1.00a/woa13_all_p_annual_01.nc)
+# min = 0, max = 9.757 from input dataset
+# divide by 1035e3 to convert from umol/l to mol/kg
+po4_src_file = INPUT/woa13_all_p_annual_01.nc
+po4_src_var_name = p_an
+po4_src_var_unit = micromoles_per_liter
+po4_dest_var_name =  po4
+po4_dest_var_unit = mol kg-1
+po4_src_var_record = 1
+po4_src_var_gridspec = NONE
+po4_valid_min = 0.0
+#
+# Alkalinity from GLODAP  (/archive/jgj/datasets/retrospective/glodap/20151013/Alk.nc)
+# min = 2171, max = 2462 from input dataset
+# divide by 1e6 to convert from umol/kg to mol/kg
+alk_src_file = INPUT/Alk.nc
+alk_src_var_name = Alk
+alk_src_var_unit = micromoles_per_kg
+alk_dest_var_name =  alk
+alk_dest_var_unit = mol kg-1
+alk_src_var_record = 1
+alk_src_var_gridspec = NONE
+alk_valid_min = 0.0
+#
+# Preind DIC from GLODAP  (/archive/jgj/datasets/retrospective/glodap/20151013/Preind_DIC.nc)
+# min = 1837, max = 2406 from input dataset
+# divide by 1e6 to convert from umol/kg to mol/kg
+dic_src_file = INPUT/Preind_DIC.nc
+dic_src_var_name = Preind_DIC
+dic_src_var_unit = micromoles_per_kg
+dic_dest_var_name =  dic
+dic_dest_var_unit = mol kg-1
+dic_src_var_record = 1
+dic_src_var_gridspec = NONE
+dic_valid_min = 0.0
+#
+# min = 0,  max = 4.446 from input dataset
+chl_src_file = INPUT/init_ocean_cobalt.res.nc
+chl_src_var_name = chl
+chl_src_var_unit = none
+chl_dest_var_name =  chl
+chl_dest_var_unit = mol kg-1
+chl_src_var_record = 1
+chl_src_var_gridspec = NONE
+chl_valid_min = 0.0
+#
+# min = 0,  max = 3.576E-04 from input dataset
+co3_ion_src_file = INPUT/init_ocean_cobalt.res.nc
+co3_ion_src_var_name = co3_ion
+co3_ion_src_var_unit = none
+co3_ion_dest_var_name =  co3_ion
+co3_ion_dest_var_unit = mol kg-1
+co3_ion_src_var_record = 1
+co3_ion_src_var_gridspec = NONE
+co3_ion_valid_min = 0.0
+#
+# min = -1.758E-11,  max = 1.758E-08 from input dataset
+fed_src_file = INPUT/init_ocean_cobalt.res.nc
+fed_src_var_name = fed
+fed_src_var_unit = none
+fed_dest_var_name =  fed
+fed_dest_var_unit = mol kg-1
+fed_src_var_record = 1
+fed_src_var_gridspec = NONE
+fed_valid_min = 0.0
+#
+# min = 10^-8.4=3.981E-09,  max = 10^-7.9 = 1.259E-08 from input dataset
+htotal_src_file = INPUT/init_ocean_cobalt.res.nc
+htotal_src_var_name = htotal
+htotal_src_var_unit = none
+htotal_dest_var_name =  htotal
+htotal_dest_var_unit = mol kg-1
+htotal_src_var_record = 1
+htotal_src_var_gridspec = NONE
+htotal_valid_min = 3.981E-09
+htotal_valid_max = 1.259E-08
+#
+# min = 0,  max = 137.7 from input dataset
+irr_mem_src_file = INPUT/init_ocean_cobalt.res.nc
+irr_mem_src_var_name = irr_mem
+irr_mem_src_var_unit = none
+irr_mem_dest_var_name =  irr_mem
+irr_mem_dest_var_unit = mol kg-1
+irr_mem_src_var_record = 1
+irr_mem_src_var_gridspec = NONE
+irr_mem_valid_min = 0.0
+#
+# min = -1.257E-11,  max = 3.831E-07 from input dataset
+dop_src_file = INPUT/init_ocean_cobalt.res.nc
+dop_src_var_name = srdop
+dop_src_var_unit = none
+dop_dest_var_name =  dop
+dop_dest_var_unit = mol kg-1
+dop_src_var_record = 1
+dop_src_var_gridspec = NONE
+dop_valid_min = 0.0
+#
+# phyto biomass
+biomass_p_src_file = INPUT/init_ocean_cobalt_phyto_biomass.res.nc
+biomass_p_src_var_name = phyto_biomass
+biomass_p_src_var_unit = none
+biomass_p_dest_var_name =  biomass_p
+biomass_p_dest_var_unit = mol kg-1
+biomass_p_src_var_record = 1
+biomass_p_src_var_gridspec = NONE
+biomass_p_valid_min = 0.0
+#
+# min = 0 from input dataset
+cased_src_file = INPUT/init_ocean_cobalt.res.nc
+cased_src_var_name = cased
+cased_src_var_unit = none
+cased_dest_var_name =  cased
+cased_dest_var_unit = mol kg-1
+cased_src_var_record = 1
+cased_src_var_gridspec = NONE
+cased_valid_min = 0.0
+#
+/
+###........................................
+

--- a/src/checkout.sh
+++ b/src/checkout.sh
@@ -39,3 +39,17 @@ if [[ ! -d letkf ]] ; then
 else
     echo 'Skip.  Directory letkf already exists.'
 fi
+
+# -------------------------------------------------
+# option to check out generic tracer and bgc modules
+# X.Liu 03/27/2020
+echo ocean biogeochemical modules checkout ... 
+if [[ ! -d DATM-MOM6-CICE5.fd/MOM6/src/ocean_BGC/generic_tracers ]] ; then
+    git clone --single-branch --branch noaa-emc https://github.com/NOAA-EMC/ocean_BGC.git DATM-MOM6-CICE5.fd/MOM6/src/ocean_BGC
+    cd DATM-MOM6-CICE5.fd/MOM6/src/ocean_BGC
+    git submodule update --init --recursive
+    cd ${topdir}
+else
+    echo 'Skip.  Directory ocean_BGC/generic_tracers already exists.'
+fi
+# -------------------------------------------------

--- a/src/checkout.sh
+++ b/src/checkout.sh
@@ -52,4 +52,6 @@ if [[ ! -d DATM-MOM6-CICE5.fd/MOM6/src/ocean_BGC/generic_tracers ]] ; then
 else
     echo 'Skip.  Directory ocean_BGC/generic_tracers already exists.'
 fi
+# temporary solution: replacing MOM6 compile.sh file for ocean_BGC compiling
+cp -f /scratch2/NCEPDEV/marineda/Xiao.Liu/compile.sh DATM-MOM6-CICE5.fd/MOM6
 # -------------------------------------------------


### PR DESCRIPTION
Hello. I added BLING (and a few other biogeochemical) modules to MOM6 as generic tracers such that we can simulate and assimilate ocean color observables. Temporary solutions to 1) checking out and 2) building ocean_BGC modules was added to checkout.sh but these changes eventually need to be moved to the cloning process of NOAA-EMC/DATM-MOM6-CICE5 (because ocean_BGC modules are essentially part of it) and NOAA-EMC/MOM6-interface/compile.sh. Also, I believe that eventually we would want to control the options in compile.sh (e.g. compile_MOM6_LIB=1/0, compile_MOM6_BGC_LIB=1/0, etc) from yaml file(s). For now, I just added a flag for optional compiling for MOM6_BGC_LIB. FYI, BLING adds about 15% more computing time compared to MOM6 physics alone based on several fcst_only tests. Please let's discuss how we want to proceed. Thanks.

