### PR TITLE
Feature/letkf.recen.fix

### DIFF
--- a/jobs/JJOB_COPY_ENSEMBLE
+++ b/jobs/JJOB_COPY_ENSEMBLE
@@ -32,8 +32,8 @@ cat <<EOF
 EOF
                echo Copying external ICs for ensemble member $MEMBER_NO
                mkdir -p $nextic
-	       cp $EXPDIR/../../ENS_ICs/mem${MEMBER_NO}/MOM*.nc $nextic
-               cp -r $EXPDIR/../../ENS_ICs/mem${MEMBER_NO}/restart $nextic
+	       cp $EXPDIR/../../../ENS_ICs/mem${MEMBER_NO}/MOM*.nc $nextic
+               cp -r $EXPDIR/../../../ENS_ICs/mem${MEMBER_NO}/restart $nextic
             fi
          done
       fi

--- a/jobs/JJOB_LETKF
+++ b/jobs/JJOB_LETKF
@@ -39,6 +39,10 @@ else
 fi
 
 if [ -f "${ROOT_GODAS_DIR}/build/letkf/bin/letkfdriver" ]; then
+
+    if [[ -d /work ]] ; then
+    	source ${ROOT_GODAS_DIR}/src/letkf/config/env.orion
+    fi
  
     srun -n $NPE ${ROOT_GODAS_DIR}/build/letkf/bin/letkfdriver ${LETKFDIR}/yaml/letkf.yaml
 

--- a/jobs/JJOB_LETKF_RECEN
+++ b/jobs/JJOB_LETKF_RECEN
@@ -29,20 +29,32 @@ for MEMBER_NO in $(seq $ENSBEG $ENSEND); do
    echo
    echo Running Checkpoint for the $MEMBER_NO
 
+   #Add h 3d field in ana files
+   if [ -d /work ] ; then module load nco/4.8.1; fi
+   ncap2 -O -s 'h[time,vt1,lat,lon]=0.0' ${LETKFDIR}/ocn.ana.$MEMBER_NO.nc ${LETKFDIR}/ocn.ana.$MEMBER_NO.nc
+   ncks -A -C -v h ${LETKFDIR}/Data/ocn.pert.ens.$MEMBER_NO.nc ${LETKFDIR}/ocn.ana.$MEMBER_NO.nc 
+
    cp ${LETKFDIR}/ocn.ana.$MEMBER_NO.nc ${LETKFDIR}/Data/ocn.ana.$MEMBER_NO.nc
-   # srun -n $NPE ${SOCA_EXEC}/soca_checkpoint_model.x ./yaml/checkpointmodel$MEMBER_NO.yml
+   #TMP fix nan salt value problem caused by soca_pert
+   if [ -f "${LETKFDIR}/Data/tmp.nc" ]; then rm ${LETKFDIR}/Data/tmp.nc; fi
+   python $ROOT_GODAS_DIR/test/check_nan.py ${LETKFDIR}/Data/ocn.ana.$MEMBER_NO.nc ${LETKFDIR}/Data/tmp.nc
+   ncks -A -C -v Salt ${LETKFDIR}/Data/tmp.nc ${LETKFDIR}/Data/ocn.ana.$MEMBER_NO.nc
+   #checkpoint
+   srun -n $NPE ${SOCA_EXEC}/soca_checkpoint_model.x ./yaml/checkpointmodel$MEMBER_NO.yml
 
    # TODO: The ice is not pertubated but eventually, it will.
    # ciceprep_func "${RUNCDATE}/Data/cic.pert.ens.*.nc"                   
 
    mkdir -p ${LETKFDIR}/mem$MEMBER_NO
 
-   #mv -f RESTART/* ${LETKFDIR}/mem$MEMBER_NO
+   mv -f RESTART/* ${LETKFDIR}/mem$MEMBER_NO
 done
 
-for MEMBER_NO in $(seq $ENSBEG $ENSEND); do
-    mv ${LETKFDIR}/ocn.ana.$MEMBER_NO*.nc ${LETKFDIR}/Data
-    ln -s ${LETKFDIR}/mem$MEMBER_NO/MOM.res.nc ocn.ana.$MEMBER_NO.nc 
-done
+if [ -f "${LETKFDIR}/Data/tmp.nc" ]; then rm ${LETKFDIR}/Data/tmp.nc; fi
 
-# srun -n $NPE ${SOCA_EXEC}/soca_ensrecenter.x ./yaml/ensrecenter.yml
+#for MEMBER_NO in $(seq $ENSBEG $ENSEND); do
+#    mv ${LETKFDIR}/ocn.ana.$MEMBER_NO*.nc ${LETKFDIR}/Data
+#    ln -s ${LETKFDIR}/mem$MEMBER_NO/MOM.res.nc ocn.ana.$MEMBER_NO.nc 
+#done
+
+srun -n $NPE ${SOCA_EXEC}/soca_ensrecenter.x ./yaml/ensrecenter.yml

--- a/modulefiles/hera.intel19
+++ b/modulefiles/hera.intel19
@@ -3,7 +3,7 @@
 ##
 
 module use -a /scratch2/NCEPDEV/marineda/Yi-cheng.Teng/opt/modulefiles/core
-module use -a scratch2/NCEPDEV/marineda/Yi-cheng.Teng/opt/modulefiles/apps
+module use -a /scratch2/NCEPDEV/marineda/Yi-cheng.Teng/opt/modulefiles/apps
 module load intel-impi-19.0.5-ecbuild-develop
 
 #module use /scratch1/NCEPDEV/jcsda/Ryan.Honeyager/jedi/modules

--- a/scripts/icec_prep_obs.sh
+++ b/scripts/icec_prep_obs.sh
@@ -15,10 +15,10 @@ if [ -f "${PREPROCobs}" ]; then
 
    cp -rf ${PREPROCobs} ${ObsRunDir}/ioda.icec.cat_l2.emc_LARGE.nc
 
-   # Create record dim
-   ncks --mk_rec_dmn nlocs ${ObsRunDir}/ioda.icec.cat_l2.emc_LARGE.nc ${ObsRunDir}/icec-tmp.nc
    # Subsample
-   ncks -O -F -d nlocs,1,,5 ${ObsRunDir}/icec-tmp.nc ${PROCobs}
+   ncks -O -F -d nlocs,1,,5 ${ObsRunDir}/ioda.icec.cat_l2.emc_LARGE.nc ${ObsRunDir}/icec-tmp.nc 
+   # Create record dim
+   ncks --mk_rec_dmn nlocs ${ObsRunDir}/icec-tmp.nc ${PROCobs} 
    rm ${ObsRunDir}/icec-tmp.nc
    rm ${ObsRunDir}/ioda.icec.cat_l2.emc_LARGE.nc
 

--- a/scripts/prep_letkf.sh
+++ b/scripts/prep_letkf.sh
@@ -84,7 +84,7 @@ export bkg_date=$(cdate2bkg_date $CDATE)
 echo "bkg_date="$bkg_date
 
 ${ROOT_GODAS_DIR}/scripts/prep_BKG_DATE_yaml.sh    \
-      -i $RUNCDATE/yaml/ensrecenter.yml    \
+      -i $LETKFDIR/yaml/ensrecenter.yml    \
       -d ${bkg_date}
 
 ${ROOT_GODAS_DIR}/scripts/prep_recenter_yaml.sh     \

--- a/test/check_nan.py
+++ b/test/check_nan.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+
+import sys
+import netCDF4
+import numpy as np
+
+input_file = str(sys.argv[1])
+output_file = str(sys.argv[2])
+
+print ('input_file:', input_file)
+print ('output_file:', output_file)
+
+dset = netCDF4.Dataset(input_file, 'r+')
+arr=dset['Salt'][:].data[:]
+arr[np.isnan(arr)]=0.1
+
+f = netCDF4.Dataset(output_file,'w')
+f.createDimension('time',arr.shape[0])
+f.createDimension('vt1',arr.shape[1])
+f.createDimension('lat',arr.shape[2])
+f.createDimension('lon',arr.shape[3])
+
+v = f.createVariable('Salt',np.double,('time','vt1','lat','lon'))
+v[:] = arr[:]
+
+f.close()
+dset.close()

--- a/ush/load_godas_modules.sh
+++ b/ush/load_godas_modules.sh
@@ -30,7 +30,9 @@ elif [[ -d /work ]] ; then
                 source $ROOT_GODAS_DIR/modulefiles/orion.intel19
         fi 
         if [[ $1 = 'fcst' ]] ; then
+                module purge
                 source $ROOT_GODAS_DIR/modulefiles/orion.fcst
+                source $ROOT_GODAS_DIR/modulefiles/orion.anaconda
         fi
 else
     echo WARNING: UNKNOWN PLATFORM 


### PR DESCRIPTION
## Description
Quick fixed soca checkpoint & recenter issues caused by UMD-LETKF. 

### Issue(s) addressed
Currently UMD-letkf outputs do not work with soca-checkpoint application due to the missing of 3D field of grid thickness.
The perturbed ICs generated by soca-enspert contain NaN which will crash model fcst run.

## Testing
IC-ens case & letkf_only cases work on both Hera & Orion.
