### PR TITLE
soca and ufo config for the 3dvar application

### DIFF
--- a/soca/fields_metadata.yaml
+++ b/soca/fields_metadata.yaml
@@ -1,0 +1,241 @@
+# --------------------------------------------------------------------------------------------------
+# Field metadata for SOCA. Each field can contain the following information:
+#
+# name:                 Internal name used by soca code and config files
+# grid:                 "h", "u", or "v"    (Default: h)
+# masked:               use land mask if true  (Default: true)
+# levels:               "1" or "full_ocn"   (Default: 1)
+# getval_name:          variable name expected by GetValues  (Default: <name>)
+# getval_name_surface:  GetValues variable name for 2D surface of a 3D field (Default: <unused>)
+# io_file:              The restart file domain "ocn", "sfc", or "ice" (Default: <unused>)
+# io_name:              The variable name used in the restart IO (Default: <unused>)
+# dummy_atm:            Don't use this. (It's a temporary hack for CRTM stuff)
+# --------------------------------------------------------------------------------------------------
+
+
+# --------------------------------------------------------------------------------------------------
+# Ocean state variables
+# --------------------------------------------------------------------------------------------------
+- name: tocn
+  levels: full_ocn
+  getval name: sea_water_potential_temperature
+  getval name surface: sea_surface_temperature
+  io file: ocn
+  io name: Temp
+
+- name: socn
+  levels: full_ocn
+  getval name: sea_water_salinity
+  getval name surface: sea_surface_salinity
+  io file: ocn
+  io name: Salt
+  property: positive_definite
+
+- name: uocn
+  grid: u
+  levels: full_ocn
+  getval name: eastward_sea_water_velocity
+  getval name surface: surface_eastward_sea_water_velocity
+  io file: ocn
+  io name: u
+
+- name: vocn
+  grid: v
+  levels: full_ocn
+  getval name: northward_sea_water_velocity
+  getval name surface: surface_northward_sea_water_velocity
+  io file: ocn
+  io name: v
+
+- name: hocn
+  levels: full_ocn
+  getval name: sea_water_cell_thickness
+  io file: ocn
+  io name: h
+
+- name: ssh
+  getval name: sea_surface_height_above_geoid
+  io file: ocn
+  io name: ave_ssh
+
+
+# --------------------------------------------------------------------------------------------------
+# ice state variables
+# --------------------------------------------------------------------------------------------------
+- name: hicen
+  getval name: sea_ice_category_thickness
+  io file: ice
+  io name: hicen
+  property: positive_definite
+
+- name: cicen
+  getval name: sea_ice_category_area_fraction
+  getval name surface: sea_ice_area_fraction     # note: not accurate, should be "sum" not "surface"
+  io file: ice
+  io name: aicen
+
+- name: hsnon
+  getval name: sea_ice_category_snow_thickness
+  io file: ice
+  io name: hsnon
+  property: positive_definite
+
+# --------------------------------------------------------------------------------------------------
+# sea surface variables
+# --------------------------------------------------------------------------------------------------
+- name: sw
+  masked: false
+  getval name: net_downwelling_shortwave_radiation
+  io file: sfc
+  io name: sw_rad
+
+- name: lw
+  masked: false
+  getval name: net_downwelling_longwave_radiation
+  io file: sfc
+  io name: lw_rad
+
+- name: lhf
+  masked: false
+  getval name: upward_latent_heat_flux_in_air
+  io file: sfc
+  io name: latent_heat
+
+- name: shf
+  masked: false
+  getval name: upward_sensible_heat_flux_in_air
+  io file: sfc
+  io name: sens_heat
+
+- name: us
+  masked: false
+  getval name: friction_velocity_over_water
+  io file: sfc
+  io name: fric_vel
+
+
+# --------------------------------------------------------------------------------------------------
+# BGC
+# --------------------------------------------------------------------------------------------------
+- name: chl
+  levels: full_ocn
+  getval name: mass_concentration_of_chlorophyll_in_sea_water
+  getval name surface: sea_surface_chlorophyll
+  io file: ocn
+  io name: chl
+  property: positive_definite
+
+- name: biop
+  levels: full_ocn
+  getval name: molar_concentration_of_biomass_in_sea_water_in_p_units
+  getval name surface: sea_surface_biomass_in_p_units
+  io file: ocn
+  io name: biomass_p
+  property: positive_definite
+
+# --------------------------------------------------------------------------------------------------
+# built-in derived variables that you don't need to worry about
+# --------------------------------------------------------------------------------------------------
+- name: distance_from_coast
+  masked: false
+
+- name: layer_depth
+  levels: full_ocn
+
+- name: mesoscale_representation_error
+
+- name: mld
+
+- name: sea_floor_depth_below_sea_surface
+
+- name: sea_area_fraction
+  masked: false
+
+- name: surface_temperature_where_sea
+
+
+# --------------------------------------------------------------------------------------------------
+# Dummy fields that aren't actually used.
+# Needed for the CRTM hack to work
+# these should all be removed at some point when coupled hofx is implemented correctly
+# --------------------------------------------------------------------------------------------------
+- name: air_pressure
+  dummy_atm: true
+
+- name: air_pressure_levels
+  dummy_atm: true
+
+- name: air_temperature
+  dummy_atm: true
+
+- name: humidity_mixing_ratio
+  dummy_atm: true
+
+- name: effective_radius_of_cloud_liquid_water_particle
+  dummy_atm: true
+
+- name: effective_radius_of_cloud_ice_particle
+  dummy_atm: true
+
+- name: mass_content_of_cloud_ice_in_atmosphere_layer
+  dummy_atm: true
+
+- name: mass_content_of_cloud_liquid_water_in_atmosphere_layer
+  dummy_atm: true
+
+- name: mole_fraction_of_carbon_dioxide_in_air
+  dummy_atm: true
+
+- name: mole_fraction_of_ozone_in_air
+  dummy_atm: true
+
+- name: surface_wind_from_direction
+  dummy_atm: true
+
+- name: soil_type
+  dummy_atm: true
+
+- name: leaf_area_index
+  dummy_atm: true
+
+- name: vegetation_type_index
+  dummy_atm: true
+
+- name: surface_wind_speed
+  dummy_atm: true
+
+- name: surface_snow_thickness
+  dummy_atm: true
+
+- name: vegetation_area_fraction
+  dummy_atm: true
+
+- name: land_type_index
+  dummy_atm: true
+
+- name: volume_fraction_of_condensed_water_in_soil
+  dummy_atm: true
+
+- name: soil_temperature
+  dummy_atm: true
+
+- name: surface_temperature_where_snow
+  dummy_atm: true
+
+- name: surface_temperature_where_ice
+  dummy_atm: true
+
+- name: surface_temperature_where_land
+  dummy_atm: true
+
+- name: surface_snow_area_fraction
+  dummy_atm: true
+
+- name: ice_area_fraction
+  dummy_atm: true
+
+- name: land_area_fraction
+  dummy_atm: true
+
+- name: water_area_fraction
+  dummy_atm: true

--- a/soca/obs/adt_3a.yaml
+++ b/soca/obs/adt_3a.yaml
@@ -1,0 +1,59 @@
+- obs space:
+    name: adt_3a
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/adt_3a.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).adt_3a.{{window_begin}}.nc4
+    simulated variables: [absolute_dynamic_topography]
+  obs operator:
+    name: ADT
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      minvalue: 5.0
+  - filter: Background Check
+    absolute threshold: 0.2
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_floor_depth_below_sea_surface@GeoVaLs}
+      minvalue: 500
+  - filter: Perform Action
+    action:
+      name: assign error
+      error function:
+        name: LinearCombination@ObsFunction
+        options:
+          variables: [mesoscale_representation_error@GeoVaLs,
+                      absolute_dynamic_topography@ObsError]
+          coefs: [0.1,
+                  2.0]
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: -125
+      maxvalue: -90
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: 60
+      maxvalue: 110

--- a/soca/obs/adt_c2.yaml
+++ b/soca/obs/adt_c2.yaml
@@ -1,0 +1,59 @@
+- obs space:
+    name: adt_c2
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/adt_c2.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).adt_c2.{{window_begin}}.nc4
+    simulated variables: [absolute_dynamic_topography]
+  obs operator:
+    name: ADT
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      minvalue: 5.0
+  - filter: Background Check
+    absolute threshold: 0.2
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_floor_depth_below_sea_surface@GeoVaLs}
+      minvalue: 500
+  - filter: Perform Action
+    action:
+      name: assign error
+      error function:
+        name: LinearCombination@ObsFunction
+        options:
+          variables: [mesoscale_representation_error@GeoVaLs,
+                      absolute_dynamic_topography@ObsError]
+          coefs: [0.1,
+                  2.0]
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: -125
+      maxvalue: -90
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: 60
+      maxvalue: 110

--- a/soca/obs/adt_coperl4.yaml
+++ b/soca/obs/adt_coperl4.yaml
@@ -1,0 +1,39 @@
+- obs space:
+    name: adt_coperl4
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/adt_coperl4.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).adt_coperl4.{{window_begin}}.nc4
+    simulated variables: [absolute_dynamic_topography]
+  obs operator:
+    name: ADT
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  # Reject obs where ocean fraction is < 90%
+  - filter: Domain Check
+    action:
+      name: reject
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      minvalue: 0.9
+  # Passivate obs where ocean fraction is > 90%
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      maxvalue: 0.9
+  # Reject obs outside of [-4.0m,4.0m]
+  - filter: Bounds Check
+    action:
+      name: reject
+    minvalue: -4.0
+    maxvalue: 4.0

--- a/soca/obs/adt_j2.yaml
+++ b/soca/obs/adt_j2.yaml
@@ -1,0 +1,59 @@
+- obs space:
+    name: adt_j2
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/adt_j2.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).adt_j2.{{window_begin}}.nc4
+    simulated variables: [absolute_dynamic_topography]
+  obs operator:
+    name: ADT
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      minvalue: 5.0
+  - filter: Background Check
+    absolute threshold: 0.2
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_floor_depth_below_sea_surface@GeoVaLs}
+      minvalue: 500
+  - filter: Perform Action
+    action:
+      name: assign error
+      error function:
+        name: LinearCombination@ObsFunction
+        options:
+          variables: [mesoscale_representation_error@GeoVaLs,
+                      absolute_dynamic_topography@ObsError]
+          coefs: [0.1,
+                  2.0]
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: -125
+      maxvalue: -90
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: 60
+      maxvalue: 110

--- a/soca/obs/adt_j3.yaml
+++ b/soca/obs/adt_j3.yaml
@@ -1,0 +1,59 @@
+- obs space:
+    name: adt_j3
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/adt_j3.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).adt_j3.{{window_begin}}.nc4
+    simulated variables: [absolute_dynamic_topography]
+  obs operator:
+    name: ADT
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      minvalue: 5.0
+  - filter: Background Check
+    absolute threshold: 0.2
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_floor_depth_below_sea_surface@GeoVaLs}
+      minvalue: 500
+  - filter: Perform Action
+    action:
+      name: assign error
+      error function:
+        name: LinearCombination@ObsFunction
+        options:
+          variables: [mesoscale_representation_error@GeoVaLs,
+                      absolute_dynamic_topography@ObsError]
+          coefs: [0.1,
+                  2.0]
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: -125
+      maxvalue: -90
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: 60
+      maxvalue: 110

--- a/soca/obs/adt_sa.yaml
+++ b/soca/obs/adt_sa.yaml
@@ -1,0 +1,59 @@
+- obs space:
+    name: adt_sa
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/adt_sa.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).adt_sa.{{window_begin}}.nc4
+    simulated variables: [absolute_dynamic_topography]
+  obs operator:
+    name: ADT
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      minvalue: 5.0
+  - filter: Background Check
+    absolute threshold: 0.2
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_floor_depth_below_sea_surface@GeoVaLs}
+      minvalue: 500
+  - filter: Perform Action
+    action:
+      name: assign error
+      error function:
+        name: LinearCombination@ObsFunction
+        options:
+          variables: [mesoscale_representation_error@GeoVaLs,
+                      absolute_dynamic_topography@ObsError]
+          coefs: [0.1,
+                  2.0]
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: -125
+      maxvalue: -90
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: 60
+      maxvalue: 110

--- a/soca/obs/icec_EMC.yaml
+++ b/soca/obs/icec_EMC.yaml
@@ -1,0 +1,28 @@
+- obs space:
+    name: icec_EMC
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/icec_EMC.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icec_EMC.{{window_begin}}.nc4
+    simulated variables: [sea_ice_area_fraction]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: 0.0
+    maxvalue: 1.0
+  - filter: Background Check
+    threshold: 1.0
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      maxvalue: 0.9

--- a/soca/obs/icefb_GDR.yaml
+++ b/soca/obs/icefb_GDR.yaml
@@ -1,0 +1,36 @@
+- obs space:
+    name: icefb_GDR
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/icefb_GDR.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icefb_GDR.{{window_begin}}.nc4
+    simulated variables:  [sea_ice_freeboard]
+  obs operator:
+    name: SeaIceThickness
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -0.1
+    maxvalue: 1.0
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      maxvalue: -0.5
+  - filter: Background Check
+    threshold: 3.0
+  - filter: Domain Check
+    filter variables:
+    - name: sea_ice_freeboard
+    where:
+    - variable:
+        name: sea_ice_category_thickness@GeoVaLs
+      minvalue: 0.5
+      maxvalue: 5.0

--- a/soca/obs/icet.yaml
+++ b/soca/obs/icet.yaml
@@ -1,0 +1,26 @@
+- obs space:
+    name: icet___OBS_PLAT__
+    obsdatain:  {obsfile: __OBS_IN_FILE__}
+    obsdataout: {obsfile: __OBS_OUT_DIR__/icet___OBS_PLAT__.nc}
+    simulated variables: [sea_ice_category_thickness]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: 0.0
+    maxvalue: 10.0
+  - filter: Background Check
+    threshold: 500.0
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_category_thickness@GeoVaLs}
+      minvalue: 0.1

--- a/soca/obs/oc_snpp.yaml
+++ b/soca/obs/oc_snpp.yaml
@@ -1,0 +1,33 @@
+- obs space:
+    name: oc_snpp
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/oc_snpp.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).oc_snpp.{{window_begin}}.nc4
+    simulated variables: [mass_concentration_of_chlorophyll_in_sea_water]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Gaussian_Thinning
+    horizontal_mesh:   11
+    use_reduced_horizontal_grid: false
+  - filter: Bounds Check
+    minvalue: 0.001
+    maxvalue: 30.0
+  - filter: BlackList
+    where:
+    - variable:
+        name: mass_concentration_of_chlorophyll_in_sea_water@PreQC
+      any_bit_set_of: 0,1,3,4,5,8,9,10,12,14,15,16,19,21,22,25
+    action:
+      name: inflate error
+      inflation factor: 1.5

--- a/soca/obs/radiance_gmi.yaml
+++ b/soca/obs/radiance_gmi.yaml
@@ -1,0 +1,22 @@
+- obs space:
+    name: GMI-GPM
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/radiance_gmi.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).radiance_gmi.{{window_begin}}.nc4
+    simulated variables: [brightness_temperature]
+    channels: 1-13
+  obs operator:
+    name: CRTM
+    Absorbers: [H2O,O3,CO2]
+    Clouds: [Water, Ice] #, Rain, Snow]
+    Cloud_Fraction: 1.0
+    #SurfaceWindGeoVars: uv
+    obs options:
+      Sensor_ID: gmi_gpm
+      EndianType: little_endian
+      CoefficientPath: Data/crtm/
+  obs filters:
+  - *obs_land_mask
+#  - filter: GOMsaver
+#    filename: __OBS_OUT_DIR__/radiance___OBS_PLAT___geovals.nc

--- a/soca/obs/radiance_smap.yaml
+++ b/soca/obs/radiance_smap.yaml
@@ -1,0 +1,20 @@
+- obs space:
+    name: RADIOMETER-SMAP
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/radiance_smap.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).radiance_smap.{{window_begin}}.nc4
+    simulated variables: [brightness_temperature]
+    channels: 1-2
+  obs operator:
+    name: CRTM
+    Absorbers: [H2O,O3,CO2]
+    Cloud_Fraction: 1.0
+    obs options:
+      Sensor_ID: radiometer_smap
+      EndianType: little_endian
+      CoefficientPath: Data/crtm/
+  obs filters:
+  - *obs_land_mask
+#  - filter: GOMsaver
+#    filename: __OBS_OUT_DIR__radiance___OBS_PLAT___geovals.nc

--- a/soca/obs/salt_hgodas.yaml
+++ b/soca/obs/salt_hgodas.yaml
@@ -1,0 +1,27 @@
+- obs space:
+    name: insitu_s_hgodas
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/salt_hgodas.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).salt_hgodas.{{window_begin}}.nc4
+    simulated variables: [sea_water_salinity]
+  obs operator:
+    name: MarineVertInterp
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_water_salinity@ObsError}
+      minvalue: 0.0001
+  - filter: Bounds Check
+    minvalue: 1.0
+    maxvalue: 40.0
+

--- a/soca/obs/sss_smap.yaml
+++ b/soca/obs/sss_smap.yaml
@@ -1,0 +1,34 @@
+- obs space:
+    name: sss_smap
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sss_smap.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sss_smap.{{window_begin}}.nc4
+    simulated variables: [sea_surface_salinity]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: 0.1
+    maxvalue: 40.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 10.0
+
+  ## Gaussian_Thinning is having problems with LETKF, try again later
+  # - filter: Gaussian_Thinning
+  #   horizontal_mesh:   25.0 #km

--- a/soca/obs/sst_amsr2_l3u.yaml
+++ b/soca/obs/sst_amsr2_l3u.yaml
@@ -1,0 +1,35 @@
+- obs space:
+    name: sst_amsr2_l3u
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_amsr2_l3u.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_amsr2_l3u.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001
+# Make all MW sst passive for now
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      maxvalue: 0.9

--- a/soca/obs/sst_drifter.yaml
+++ b/soca/obs/sst_drifter.yaml
@@ -1,0 +1,38 @@
+- obs space:
+    name: sst_drifter
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_drifter.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_drifter.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  # Reject obs where ocean fraction is < 90%
+  - filter: Domain Check
+    action:
+      name: reject
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      minvalue: 0.9
+  # Passivate obs where ocean fraction is > 90%
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      maxvalue: 0.9
+  # Reject obs outside of [-2.0C,36.0C]
+  - filter: Bounds Check
+    action:
+      name: reject
+    minvalue: -2.0
+    maxvalue: 36.0

--- a/soca/obs/sst_gmi_l3u.yaml
+++ b/soca/obs/sst_gmi_l3u.yaml
@@ -1,0 +1,35 @@
+- obs space:
+    name: sst_gmi_l3u
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_gmi_l3u.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_gmi_l3u.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001
+# Make all MW sst passive for now
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      maxvalue: 0.9

--- a/soca/obs/sst_metopa.yaml
+++ b/soca/obs/sst_metopa.yaml
@@ -1,0 +1,32 @@
+- obs space:
+    name: sst_metopa
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_metopa.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_metopa.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001
+
+  ## Gaussian_Thinning is having problems with the LETKF, try again alter
+  # - filter: Gaussian_Thinning
+  #   horizontal_mesh:   25.0 #km

--- a/soca/obs/sst_metopa_l3u.yaml
+++ b/soca/obs/sst_metopa_l3u.yaml
@@ -1,0 +1,28 @@
+- obs space:
+    name: sst_metopa_l3u
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_metopa_l3u.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_metopa_l3u.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001

--- a/soca/obs/sst_noaa18_l3u_so025.yaml
+++ b/soca/obs/sst_noaa18_l3u_so025.yaml
@@ -1,0 +1,1 @@
+sst_noaa19_l3u.yaml

--- a/soca/obs/sst_noaa19.yaml
+++ b/soca/obs/sst_noaa19.yaml
@@ -1,0 +1,32 @@
+- obs space:
+    name: sst_noaa19
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_noaa19.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_noaa19.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001
+
+  ## Gaussian_Thinning is having problems with the LETKF, try again alter
+  # - filter: Gaussian_Thinning
+  #   horizontal_mesh:   25.0 #km

--- a/soca/obs/sst_noaa19_l3u.yaml
+++ b/soca/obs/sst_noaa19_l3u.yaml
@@ -1,0 +1,28 @@
+- obs space:
+    name: sst_noaa19_l3u
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_noaa19_l3u.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_noaa19_l3u.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001

--- a/soca/obs/sst_noaa19_l3u_so025.yaml
+++ b/soca/obs/sst_noaa19_l3u_so025.yaml
@@ -1,0 +1,1 @@
+sst_noaa19_l3u.yaml

--- a/soca/obs/sst_viirs_l3u.yaml
+++ b/soca/obs/sst_viirs_l3u.yaml
@@ -1,0 +1,28 @@
+- obs space:
+    name: sst_viirs_l3u
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_viirs_l3u.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_viirs_l3u.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001

--- a/soca/obs/sst_windsat_l3u.yaml
+++ b/soca/obs/sst_windsat_l3u.yaml
@@ -1,0 +1,35 @@
+- obs space:
+    name: sst_windsat_l3u
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_windsat_l3u.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_windsat_l3u.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001
+# Make all MW sst passive for now
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      maxvalue: 0.9

--- a/soca/obs/temp_hgodas.yaml
+++ b/soca/obs/temp_hgodas.yaml
@@ -1,0 +1,42 @@
+- obs space:
+    name: insitu_t_hgodas
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/temp_hgodas.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).temp_hgodas.{{window_begin}}.nc4
+    simulated variables: [sea_water_temperature]
+  obs operator:
+    name: InsituTemperature
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_water_temperature@ObsError}
+      minvalue: 0.001
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+#  - filter: Perform Action
+#    action:
+#      name: assign error
+#      error function:
+#        name: LinearCombination@ObsFunction
+#        options:
+#          variables: [sea_water_temperature@ombg,
+#                      sea_water_temperature@ObsError]
+#          coefs: [0.1,
+#                  1.0]
+#  - filter: Domain Check
+#    action:
+#      name: passivate
+#    where:
+#    - variable: {name: sea_area_fraction@GeoVaLs}
+#      maxvalue: 0.9

--- a/soca/soca_3dvar.yaml
+++ b/soca/soca_3dvar.yaml
@@ -1,0 +1,121 @@
+# the list of background files depends on whether we're using ice
+_: &bkg_files_ocn
+    ocn_filename: MOM.res.nc
+_: &bkg_files_ocn_ice
+    ice_filename: cice.res.nc
+    << : *bkg_files_ocn
+_: &bkg_files *bkg_files___DOMAINS__
+
+# the list of correlation operators depends on whether we're using ice
+_corr:
+  - &corr_ocn {name: ocn, variables: [__DA_VARIABLES_OCN__]}
+  - &corr_ice {name: ice, variables: [__DA_VARIABLES_ICE__]}
+  - &corr_list_ocn [ *corr_ocn ]
+  - &corr_list_ocn_ice [ *corr_ocn , *corr_ice ]
+
+# placeholders used by the obs yaml files that will be placed
+#  where _OBSERVATIONS_ token is
+_: &obs_distribution RoundRobin
+_: &obs_land_mask
+  filter: Domain Check
+  where:
+  - variable: {name: sea_area_fraction@GeoVaLs}
+    minvalue: 0.9
+_: &observations
+    __OBSERVATIONS__
+
+
+variational:
+  minimizer:
+    algorithm: RPCG
+  iterations:
+  - geometry:
+      mom6_input_nml: mom_input.nml
+      fields metadata: fields_metadata.yaml
+    ninner: 150
+    gradient norm reduction: 1e-3
+    test: on
+    diagnostics:
+      departures: ombg
+    online diagnostics:
+      write increment: true
+      increment:
+        datadir: Data
+        date:  &bkg_date __DA_ANA_DATE__
+        exp: var.iter1
+        type: incr
+
+output:
+  datadir: Data
+  exp: 3dvar
+  type: an
+
+final:
+  diagnostics:
+    departures: oman
+
+cost function:
+  cost type: 3D-Var
+  window begin: __DA_WINDOW_START__
+  window length: __DA_WINDOW_LENGTH__
+  analysis variables: &soca_vars [ __DA_VARIABLES__ ]
+  geometry:
+    mom6_input_nml: mom_input.nml
+    fields metadata: fields_metadata.yaml
+
+  background:
+    read_from_file: 1
+    basename: ./bkg/
+    date: &bkg_date __DA_ANA_DATE__
+    << : *bkg_files
+    state variables: [__DA_VARIABLES__, mld, layer_depth]
+
+  background error:
+    covariance model: SocaError
+    analysis variables: [__DA_VARIABLES__]
+    date: *bkg_date
+    bump:
+      verbosity: main
+      datadir: ./bump
+      strategy: specific_univariate
+      load_nicas_local: true
+    correlation: *corr_list___DOMAINS__
+
+    linear variable change:
+      input variables: *soca_vars
+      output variables: *soca_vars
+      linear variable changes:
+
+      - linear variable change name: VertConvSOCA
+        Lz_min: 0.0
+        Lz_mld: 0
+        Lz_mld_max: 1.0
+        scale_layer_thick: 5
+
+      - linear variable change name: BkgErrFILT
+        ocean_depth_min: 0    # [m]
+        rescale_bkgerr: 1.0
+        efold_z: 2500.0       # [m]
+
+      - linear variable change name: BkgErrGODAS
+        t_min: 0.1
+        t_max: 2.0
+        t_dz:  20.0
+        t_efold: 500.0
+        s_min: 0.0
+        s_max: 0.25
+        ssh_min: 0.0   # value at EQ
+        ssh_max: 0.0   # value in Extratropics
+        ssh_phi_ex: 20 # lat of transition from extratropics
+        cicen_min: 0.1
+        cicen_max: 0.1
+        hicen_min: 0.1
+        hicen_max: 0.1
+
+      - linear variable change name: BalanceSOCA
+        dsdtmax: 0.1
+        dsdzmin: 3.0e-6
+        dtdzmin: 1.0e-6
+        nlayers: 10
+
+  observations: *observations

--- a/soca/soca_checkpoint.yaml
+++ b/soca/soca_checkpoint.yaml
@@ -1,0 +1,41 @@
+# the list of background files depends on whether we're using ice
+_: &bkg_files_ocn
+    ocn_filename: MOM.res.nc
+_: &bkg_files_ocn_ice
+    ice_filename: cice.res.nc
+    << : *bkg_files_ocn
+_: &bkg_files *bkg_files___DOMAINS__
+
+# the list of checkpoint files depends on whether we're using ice
+_: &chkpt_files_ocn
+    ocn_filename: checkpoint_ana.nc
+_: &chkpt_files_ocn_ice
+    ice_filename: ice.checkpoint_ana.nc
+    << : *chkpt_files_ocn
+_: &chkpt_files *chkpt_files___DOMAINS__
+
+resolution:
+  mom6_input_nml: mom_input.nml
+  fields metadata: fields_metadata.yaml
+
+model:
+  name: SOCA
+  tstep: PT6H
+  advance_mom6: 0
+  model variables: &soca_vars [__DA_VARIABLES__, mld, layer_depth]
+  tocn_minmax: [-1.9, 33.0]
+  socn_minmax: [0.1, 41.0]
+
+background:
+  read_from_file: 1
+  date: &date 2018-04-15T00:00:00Z
+  basename: ./RESTART_IN/
+  << : *bkg_files
+  state variables: *soca_vars
+
+analysis:
+  read_from_file: 1
+  date: *date
+  basename: ./
+  << : *chkpt_files
+  state variables: *soca_vars

--- a/soca/soca_checkpoint_regional.yaml
+++ b/soca/soca_checkpoint_regional.yaml
@@ -1,0 +1,10 @@
+variables: [socn, tocn, ssh]
+
+bounds:  
+  tocn_minmax: [-1.9, 33.0]
+  socn_minmax: [0.1, 41.0]
+
+background filename: ./RESTART_IN/MOM.res.nc
+
+analysis filename: checkpoint_ana.nc
+

--- a/soca/soca_gridgen.yaml
+++ b/soca/soca_gridgen.yaml
@@ -1,0 +1,5 @@
+geometry:
+  geom_grid_file: soca_gridspec.nc
+  full_init: true
+  mom6_input_nml: mom_input.nml
+  fields metadata: fields_metadata.yaml

--- a/soca/soca_hofx.yaml
+++ b/soca/soca_hofx.yaml
@@ -1,0 +1,40 @@
+_: &obs_distribution RoundRobin
+_: &obs_land_mask
+  filter: Domain Check
+  where:
+  - variable: {name: sea_area_fraction@GeoVaLs}
+    minvalue: 0.9
+
+# the list of variables depends on whether we're using ice
+_: &soca_vars_ocn     [socn, tocn, ssh, hocn]
+_: &soca_vars_ocn_ice [cicen, hicen, hsnon, socn, tocn, ssh, hocn]
+_: &soca_vars_ocn_ice_bgc [cicen, hicen, hsnon, socn, tocn, ssh, hocn, chl]
+_: &soca_vars *soca_vars___DOMAINS__
+
+# the list of background files depends on whether we're using ice
+_: &bkg_files_ocn
+    ocn_filename: __BKG_FILE__
+_: &bkg_files_ocn_ice
+    ice_filename: __SEAICE_BKG_FILE__
+    << : *bkg_files_ocn
+_: &bkg_files_ocn_ice_bgc
+    << : *bkg_files_ocn_ice
+_: &bkg_files *bkg_files___DOMAINS__
+
+
+geometry:
+    mom6_input_nml: mom_input.nml
+    fields metadata: fields_metadata.yaml
+
+state:
+    date: &bkg_date __DA_ANA_DATE__
+    read_from_file: 1
+    basename: ./bkg/
+    state variables: *soca_vars
+    << : *bkg_files
+
+window length: __DA_WINDOW_LENGTH__
+window begin: __DA_WINDOW_START__
+
+observations:
+  __OBSERVATIONS__

--- a/soca/soca_locinit.yaml
+++ b/soca/soca_locinit.yaml
@@ -1,0 +1,71 @@
+# BUMP Variables
+_: &bump_vars_ocn
+    [hocn, socn, tocn, ssh, uocn, vocn]
+_: &bump_vars_ocn_ice
+    [cicen, hicen, hsnon, hocn, socn, tocn, ssh, uocn, vocn]
+
+# GRID Variables
+_: &grid_vars_ocn
+    [socn, tocn, ssh, uocn, vocn]
+_: &grid_vars_ocn_ice
+    [cicen, hicen, hsnon, socn, tocn, ssh, uocn, vocn]
+
+
+# Horizontal Localization scales
+_: &rh_ocn
+    socn:   [750e3]
+    tocn:   [750e3]
+    uocn:   [750e3]
+    vocn:   [750e3]
+    ssh:    [750e3]
+_: &rh_ocn_ice
+    cicen:  [250e3]
+    hicen:  [250e3]
+    hsnon:  [250e3]
+    << : *rh_ocn
+
+# Vertical Localization scales
+_: &rv_ocn
+    socn:   [250]
+    tocn:   [250]
+    uocn:   [250]
+    vocn:   [250]
+    ssh:    [250]
+_: &rv_ocn_ice
+    cicen:  [250]
+    hicen:  [250]
+    hsnon:  [250]
+    << : *rv_ocn
+
+geometry:
+  mom6_input_nml: mom_input.nml
+  fields metadata: fields_metadata.yaml
+
+input variables: *bump_vars___DOMAINS__
+
+background:
+  read_from_file: 1
+  date: &date 2018-04-15T00:00:00Z
+  basename: ./RESTART_IN/
+  ocn_filename: MOM.res.nc
+  ice_filename: cice.res.nc
+  state variables: *bump_vars___DOMAINS__
+
+bump:
+  verbosity: main
+  prefix: soca_bump_loc
+  datadir: ./bump
+  method: loc
+  strategy: common
+  new_nicas: true
+  write_nicas_local: true
+  resol: 6.0
+  forced_radii: true
+  rh:
+    common: [750e3]
+    << : *rh___DOMAINS__
+  rv:
+    common: [250]
+    << : *rv_ocn_ice
+  grids:
+  - variables:  *grid_vars___DOMAINS__

--- a/soca/soca_rescale_seaice.yaml
+++ b/soca/soca_rescale_seaice.yaml
@@ -1,0 +1,14 @@
+# Parameters used to rescale the sea ice background
+# TODO Set the rescaling in exp.config. Empirical values, will need to be adjusted by user at some point.
+rescale:
+  alpha_min: 0.5    # Min background rescaling
+  alpha_max: 2.0    # Max background rescaling
+  minval: 1.0e-2     # Only apply the analysis if the background fraction
+                     # is more than minval
+  restore_clim: 0    # restore to clim sea-ice thickness; 1:on; 0:off; default is off
+                     # The following parameters are only needed when restore_clim = 1
+  ice_restore_file: ./INPUT/seaice.giomas.clim.1deg.nc  # A netcdf file (path included) in which to find sea-ice thickness to use for restoring
+                                                        # see https://github.com/JCSDA-internal/soca-science/wiki/soca-ufs for details
+  ice_mean_var: heff_mean # var name for mean seaice thickness
+  ice_max_var: heff_max   # var name for max seaice thickness
+  fluxconst: 0.1667       # restoration factor 1/day

--- a/soca/soca_staticbinit.yaml
+++ b/soca/soca_staticbinit.yaml
@@ -1,0 +1,51 @@
+# the list of background files depends on whether we're using ice
+_: &bkg_files_ocn
+    ocn_filename: MOM.res.nc
+_: &bkg_files_ocn_ice
+    ice_filename: cice.res.nc
+    << : *bkg_files_ocn
+_: &bkg_files *bkg_files___DOMAINS__
+
+# the list of correlation operators depends on whether we're using ice
+_corr:
+  - &corr_ocn
+    name: ocn
+    rossby mult: 1.0
+    min grid mult: 2.0
+    min value: 50.0e3
+    variables: [__DA_VARIABLES_OCN__]
+  - &corr_ice
+    name: ice
+    base value: 100.0e3
+    variables: [__DA_VARIABLES_ICE__]
+  - &corr_list_ocn [ *corr_ocn ]
+  - &corr_list_ocn_ice [ *corr_ocn , *corr_ice ]
+
+geometry:
+  mom6_input_nml: mom_input.nml
+  fields metadata: fields_metadata.yaml
+
+analysis variables: &ana_vars [__DA_VARIABLES__]
+
+background:
+  read_from_file: 1
+  date: &date 2018-04-15T00:00:00Z
+  basename: ./RESTART_IN/
+  << : *bkg_files
+  state variables: &state_vars [__DA_VARIABLES__, mld, layer_depth]
+
+background error:
+  covariance model: SocaError
+  analysis variables: *ana_vars
+  date: *date
+  bump:
+    verbosity: main
+    datadir: ./bump
+    method: cor
+    strategy: specific_univariate
+    new_nicas: true
+    write_nicas_local: true
+    mask_check: true
+    resol: 10.0
+    nc1max: 88000
+  correlation: *corr_list___DOMAINS__


### PR DESCRIPTION
## Description
Add the soca and ufo `yaml` configuration necessary to run the `3DVAR` and `h(x)` applications. 


### Issue(s) addressed
- closes #235

## Testing

1 deg and 0.25 deg over multiple month.
see here if you are curious:
```console
/work/noaa/marine/Guillaume.Vernieres/runs/s2s/notsofinal-0.25
```


