### PR TITLE
Add ufo yamls for new obsspaces

### DIFF
--- a/obs/icec_nsidc_nh.yaml
+++ b/obs/icec_nsidc_nh.yaml
@@ -1,0 +1,30 @@
+- obs space:
+    name: icec_nsidc_nh
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/icec_nsidc_nh.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icec_nsidc_nh.{{window_begin}}.nc4
+    simulated variables: [sea_ice_area_fraction]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: 0.0
+    maxvalue: 1.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      maxvalue: 0.9

--- a/obs/icec_nsidc_sh.yaml
+++ b/obs/icec_nsidc_sh.yaml
@@ -1,0 +1,30 @@
+- obs space:
+    name: icec_nsidc_sh
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/icec_nsidc_sh.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icec_nsidc_sh.{{window_begin}}.nc4
+    simulated variables: [sea_ice_area_fraction]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: 0.0
+    maxvalue: 1.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      maxvalue: 0.9

--- a/obs/icec_ssmi.yaml
+++ b/obs/icec_ssmi.yaml
@@ -1,0 +1,30 @@
+- obs space:
+    name: icec_ssmi
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/icec_ssmi.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icec_ssmi.{{window_begin}}.nc4
+    simulated variables: [sea_ice_area_fraction]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: 0.0
+    maxvalue: 1.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      maxvalue: 0.9

--- a/obs/icec_ssmis.yaml
+++ b/obs/icec_ssmis.yaml
@@ -1,0 +1,30 @@
+- obs space:
+    name: icec_ssmis
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/icec_ssmis.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icec_ssmis.{{window_begin}}.nc4
+    simulated variables: [sea_ice_area_fraction]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: 0.0
+    maxvalue: 1.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      maxvalue: 0.9

--- a/obs/salt_profile_fnmoc.yaml
+++ b/obs/salt_profile_fnmoc.yaml
@@ -1,0 +1,30 @@
+- obs space:
+    name: insitu_s_profile_fnmoc
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/salt_profile_fnmoc.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).salt_profile_fnmoc.{{window_begin}}.nc4
+    simulated variables: [sea_water_salinity]
+  obs operator:
+    name: MarineVertInterp
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_water_salinity@ObsError}
+      minvalue: 0.0001
+  - filter: Bounds Check
+    minvalue: 1.0
+    maxvalue: 40.0
+  - filter: Background Check
+    threshold: 5.0

--- a/obs/sss_smos.yaml
+++ b/obs/sss_smos.yaml
@@ -1,0 +1,36 @@
+- obs space:
+    name: sss_smos
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sss_smos.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sss_smos.{{window_begin}}.nc4
+    simulated variables: [sea_surface_salinity]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: 0.1
+    maxvalue: 40.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 10.0
+
+  ## Gaussian_Thinning is having problems with LETKF, try again later
+  # - filter: Gaussian_Thinning
+  #   horizontal_mesh:   25.0 #km

--- a/obs/sss_trak_fnmoc.yaml
+++ b/obs/sss_trak_fnmoc.yaml
@@ -1,0 +1,32 @@
+- obs space:
+    name: sss_trak_fnmoc
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sss_trak_fnmoc.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sss_trak_fnmoc.{{window_begin}}.nc4
+    simulated variables: [sea_surface_salinity]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    #     # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: 0.1
+    maxvalue: 40.0
+  #- filter: Background Check
+  #  threshold: 5.0
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 10.0

--- a/obs/sst_metopb_l3u_so025.yaml
+++ b/obs/sst_metopb_l3u_so025.yaml
@@ -1,0 +1,37 @@
+- obs space:
+    name: sst_metopb_l3u_so025
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_metopb_l3u_so025.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_metopb_l3u_so025.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001
+   #   maxvalue: 0.5
+    #action:
+    #  name: inflate error
+    #  inflation: 2.0
+  ## Gaussian_Thinning is having problems with the LETKF, try again alter
+  #- filter: Gaussian_Thinning
+  #  horizontal_mesh:  1111.949266 #km

--- a/obs/sst_metopc_l3u_so025.yaml
+++ b/obs/sst_metopc_l3u_so025.yaml
@@ -1,0 +1,37 @@
+- obs space:
+    name: sst_metopc_l3u_so025
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_metopc_l3u_so025.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_metopc_l3u_so025.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001
+    #  maxvalue: 0.5
+    #action:
+    #  name: inflate error
+    #  inflation: 2.0
+  ## Gaussian_Thinning is having problems with the LETKF, try again alter
+  #- filter: Gaussian_Thinning
+  #  horizontal_mesh:  1111.949266 #km

--- a/obs/sst_ostia.yaml
+++ b/obs/sst_ostia.yaml
@@ -1,0 +1,37 @@
+- obs space:
+    name: sst_ostia
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_ostia.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_ostia.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001
+   #   maxvalue: 0.5
+    #action:
+    #  name: inflate error
+    #  inflation: 2.0
+  ## Gaussian_Thinning is having problems with the LETKF, try again alter
+  #- filter: Gaussian_Thinning
+  #  horizontal_mesh:  1111.949266 #km

--- a/obs/sst_ship_fnmoc.yaml
+++ b/obs/sst_ship_fnmoc.yaml
@@ -1,0 +1,40 @@
+- obs space:
+    name: sst_ship_fnmoc
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_ship_fnmoc.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_ship_fnmoc.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    action:
+      name: reject
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      minvalue: 0.9
+  # Passivate obs where ocean fraction is > 90%
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      maxvalue: 0.9
+  # Reject obs outside of [-2.0C,36.0C]
+  - filter: Bounds Check
+    action:
+      name: reject
+    minvalue: -2.0
+    maxvalue: 36.0

--- a/obs/sst_trak_fnmoc.yaml
+++ b/obs/sst_trak_fnmoc.yaml
@@ -1,0 +1,40 @@
+- obs space:
+    name: sst_trak_fnmoc
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_trak_fnmoc.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_trak_fnmoc.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    action:
+      name: reject
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      minvalue: 0.9
+  # Passivate obs where ocean fraction is > 90%
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      maxvalue: 0.9
+  # Reject obs outside of [-2.0C,36.0C]
+  - filter: Bounds Check
+    action:
+      name: reject
+    minvalue: -2.0
+    maxvalue: 36.0

--- a/obs/sst_viirs_n20_l3u_so025.yaml
+++ b/obs/sst_viirs_n20_l3u_so025.yaml
@@ -1,0 +1,37 @@
+- obs space:
+    name: sst_viirs_n20_l3u_so025
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_viirs_n20_l3u_so025.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_viirs_n20_l3u_so025.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001
+   #   maxvalue: 0.5
+    #action:
+    #  name: inflate error
+    #  inflation: 2.0
+  ## Gaussian_Thinning is having problems with the LETKF, try again alter
+  #- filter: Gaussian_Thinning
+  #  horizontal_mesh:  1111.949266 #km

--- a/obs/sst_viirs_npp_l3u_so025.yaml
+++ b/obs/sst_viirs_npp_l3u_so025.yaml
@@ -1,0 +1,37 @@
+- obs space:
+    name: sst_viirs_npp_l3u_so025
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/sst_viirs_npp_l3u_so025.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sst_viirs_npp_l3u_so025.{{window_begin}}.nc4
+    simulated variables: [sea_surface_temperature]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 200e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@ObsError}
+      minvalue: 0.001
+   #   maxvalue: 0.5
+    #action:
+    #  name: inflate error
+    #  inflation: 2.0
+  ## Gaussian_Thinning is having problems with the LETKF, try again alter
+  #- filter: Gaussian_Thinning
+  #  horizontal_mesh:  1111.949266 #km

--- a/obs/temp_profile_fnmoc.yaml
+++ b/obs/temp_profile_fnmoc.yaml
@@ -1,0 +1,30 @@
+- obs space:
+    name: insitu_t_profile_fnmoc
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/temp_profile_fnmoc.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).temp_profile_fnmoc.{{window_begin}}.nc4
+    simulated variables: [sea_water_temperature]
+  obs operator:
+    name: InsituTemperature
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_water_temperature@ObsError}
+      minvalue: 0.001
+  - filter: Bounds Check
+    minvalue: -2.0
+    maxvalue: 36.0
+  - filter: Background Check
+    threshold: 5.0


### PR DESCRIPTION
This PR adds ufo yaml for new obsspaces.
The new obsspaces include:

INSITU: FNMOC profile (temp & saln), ship (SST) and trak (SST, SSS)
SST: OSTIA, superobbed (MetOp<B,C; VIIRS_<NPP,N20)
SSS: SMOS
ICEC: EMC (SSMI, SSMIS), NSIDC (NH, SH)

closes issue #242 