### PR TITLE
distance to coast filter applied to all observations

### DIFF
--- a/expconfigs/exp.config-0.25
+++ b/expconfigs/exp.config-0.25
@@ -108,7 +108,7 @@ OBS_GEN_ENABLED=F
 OBS_LIST_OCN="temp salt adt sst sss icec"
               
 OBS_ADT_LIST="3a_egm2008 3b_egm2008 6a_egm2008 j2_egm2008 j3_egm2008 c2_egm2008 sa_egm2008 coperl4"
-OBS_SST_LIST="drifter ship_fnmoc trak_fnmoc metopa_l3u_so025 metopb_l3u_so025 metopc_l3u_so025 noaa18_l3u_so025 noaa19_l3u_so025 viirs_npp_l3u_so025 viirs_n20_l3u_so025"
+OBS_SST_LIST="drifter trak_fnmoc metopa_l3u_so025 metopb_l3u_so025 metopc_l3u_so025 noaa18_l3u_so025 noaa19_l3u_so025 viirs_npp_l3u_so025 viirs_n20_l3u_so025"
 OBS_SSS_LIST="trak_fnmoc"
 OBS_SALT_LIST="profile_fnmoc"
 OBS_TEMP_LIST="profile_fnmoc"

--- a/soca/obs/adt_3a_egm2008.yaml
+++ b/soca/obs/adt_3a_egm2008.yaml
@@ -55,3 +55,7 @@
     where:
     - variable: { name: sea_ice_area_fraction@GeoVaLs}
       maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/adt_3a_egm2008.yaml
+++ b/soca/obs/adt_3a_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.1,
-                  2.0]
+          coefs: [0.5,
+                  3.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_3a_egm2008.yaml
+++ b/soca/obs/adt_3a_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  2.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_3a_egm2008.yaml
+++ b/soca/obs/adt_3a_egm2008.yaml
@@ -9,18 +9,12 @@
     name: ADT
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 500e3
   obs filters:
   - *obs_land_mask
   - filter: Domain Check
     where:
     - variable: { name: sea_surface_temperature@GeoVaLs}
-      minvalue: 5.0
+      minvalue: 15.0
   - filter: Background Check
     absolute threshold: 0.2
   - filter: Domain Check
@@ -35,8 +29,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  0.5]
   - filter: BlackList
     where:
     - variable:
@@ -57,3 +51,7 @@
         name: longitude@MetaData
       minvalue: 60
       maxvalue: 110
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001

--- a/soca/obs/adt_3b_egm2008.yaml
+++ b/soca/obs/adt_3b_egm2008.yaml
@@ -55,3 +55,7 @@
     where:
     - variable: { name: sea_ice_area_fraction@GeoVaLs}
       maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/adt_3b_egm2008.yaml
+++ b/soca/obs/adt_3b_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.1,
-                  2.0]
+          coefs: [0.5,
+                  3.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_3b_egm2008.yaml
+++ b/soca/obs/adt_3b_egm2008.yaml
@@ -1,0 +1,59 @@
+- obs space:
+    name: adt_3b_egm2008
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/adt_3b_egm2008.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).adt_3b_egm2008.{{window_begin}}.nc4
+    simulated variables: [absolute_dynamic_topography]
+  obs operator:
+    name: ADT
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      minvalue: 5.0
+  - filter: Background Check
+    absolute threshold: 0.2
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_floor_depth_below_sea_surface@GeoVaLs}
+      minvalue: 500
+  - filter: Perform Action
+    action:
+      name: assign error
+      error function:
+        name: LinearCombination@ObsFunction
+        options:
+          variables: [mesoscale_representation_error@GeoVaLs,
+                      absolute_dynamic_topography@ObsError]
+          coefs: [0.1,
+                  2.0]
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: -125
+      maxvalue: -90
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -65
+      maxvalue: -30
+    - variable:
+        name: longitude@MetaData
+      minvalue: 60
+      maxvalue: 110

--- a/soca/obs/adt_3b_egm2008.yaml
+++ b/soca/obs/adt_3b_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  2.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_3b_egm2008.yaml
+++ b/soca/obs/adt_3b_egm2008.yaml
@@ -9,18 +9,12 @@
     name: ADT
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 500e3
   obs filters:
   - *obs_land_mask
   - filter: Domain Check
     where:
     - variable: { name: sea_surface_temperature@GeoVaLs}
-      minvalue: 5.0
+      minvalue: 15.0
   - filter: Background Check
     absolute threshold: 0.2
   - filter: Domain Check
@@ -35,8 +29,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  0.5]
   - filter: BlackList
     where:
     - variable:
@@ -57,3 +51,7 @@
         name: longitude@MetaData
       minvalue: 60
       maxvalue: 110
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001

--- a/soca/obs/adt_6a_egm2008.yaml
+++ b/soca/obs/adt_6a_egm2008.yaml
@@ -55,3 +55,7 @@
     where:
     - variable: { name: sea_ice_area_fraction@GeoVaLs}
       maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/adt_6a_egm2008.yaml
+++ b/soca/obs/adt_6a_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.1,
-                  2.0]
+          coefs: [0.5,
+                  3.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_6a_egm2008.yaml
+++ b/soca/obs/adt_6a_egm2008.yaml
@@ -9,18 +9,12 @@
     name: ADT
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 500e3
   obs filters:
   - *obs_land_mask
   - filter: Domain Check
     where:
     - variable: { name: sea_surface_temperature@GeoVaLs}
-      minvalue: 5.0
+      minvalue: 15.0
   - filter: Background Check
     absolute threshold: 0.2
   - filter: Domain Check
@@ -35,8 +29,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  0.5]
   - filter: BlackList
     where:
     - variable:
@@ -57,3 +51,7 @@
         name: longitude@MetaData
       minvalue: 60
       maxvalue: 110
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001

--- a/soca/obs/adt_6a_egm2008.yaml
+++ b/soca/obs/adt_6a_egm2008.yaml
@@ -1,9 +1,9 @@
 - obs space:
-    name: adt_c2_egm2008
+    name: adt_6a_egm2008
     obsdatain:
-      obsfile: $(experiment_dir)/{{current_cycle}}/adt_c2_egm2008.{{window_begin}}.nc4
+      obsfile: $(experiment_dir)/{{current_cycle}}/adt_6a_egm2008.{{window_begin}}.nc4
     obsdataout:
-      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).adt_c2_egm2008.{{window_begin}}.nc4
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).adt_6a_egm2008.{{window_begin}}.nc4
     simulated variables: [absolute_dynamic_topography]
   obs operator:
     name: ADT

--- a/soca/obs/adt_c2_egm2008.yaml
+++ b/soca/obs/adt_c2_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.1,
-                  2.0]
+          coefs: [0.5,
+                  3.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_c2_egm2008.yaml
+++ b/soca/obs/adt_c2_egm2008.yaml
@@ -9,18 +9,12 @@
     name: ADT
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 500e3
   obs filters:
   - *obs_land_mask
   - filter: Domain Check
     where:
     - variable: { name: sea_surface_temperature@GeoVaLs}
-      minvalue: 5.0
+      minvalue: 15.0
   - filter: Background Check
     absolute threshold: 0.2
   - filter: Domain Check
@@ -35,8 +29,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  0.5]
   - filter: BlackList
     where:
     - variable:
@@ -57,3 +51,7 @@
         name: longitude@MetaData
       minvalue: 60
       maxvalue: 110
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001

--- a/soca/obs/adt_coperl4.yaml
+++ b/soca/obs/adt_coperl4.yaml
@@ -37,3 +37,7 @@
       name: reject
     minvalue: -4.0
     maxvalue: 4.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/adt_j2_egm2008.yaml
+++ b/soca/obs/adt_j2_egm2008.yaml
@@ -55,3 +55,7 @@
     where:
     - variable: { name: sea_ice_area_fraction@GeoVaLs}
       maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/adt_j2_egm2008.yaml
+++ b/soca/obs/adt_j2_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.1,
-                  2.0]
+          coefs: [0.5,
+                  3.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_j2_egm2008.yaml
+++ b/soca/obs/adt_j2_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  2.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_j2_egm2008.yaml
+++ b/soca/obs/adt_j2_egm2008.yaml
@@ -9,18 +9,12 @@
     name: ADT
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 500e3
   obs filters:
   - *obs_land_mask
   - filter: Domain Check
     where:
     - variable: { name: sea_surface_temperature@GeoVaLs}
-      minvalue: 5.0
+      minvalue: 15.0
   - filter: Background Check
     absolute threshold: 0.2
   - filter: Domain Check
@@ -35,8 +29,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  0.5]
   - filter: BlackList
     where:
     - variable:
@@ -57,3 +51,7 @@
         name: longitude@MetaData
       minvalue: 60
       maxvalue: 110
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001

--- a/soca/obs/adt_j3_egm2008.yaml
+++ b/soca/obs/adt_j3_egm2008.yaml
@@ -55,3 +55,7 @@
     where:
     - variable: { name: sea_ice_area_fraction@GeoVaLs}
       maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/adt_j3_egm2008.yaml
+++ b/soca/obs/adt_j3_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.1,
-                  2.0]
+          coefs: [0.5,
+                  3.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_j3_egm2008.yaml
+++ b/soca/obs/adt_j3_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  2.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_j3_egm2008.yaml
+++ b/soca/obs/adt_j3_egm2008.yaml
@@ -9,18 +9,12 @@
     name: ADT
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 500e3
   obs filters:
   - *obs_land_mask
   - filter: Domain Check
     where:
     - variable: { name: sea_surface_temperature@GeoVaLs}
-      minvalue: 5.0
+      minvalue: 15.0
   - filter: Background Check
     absolute threshold: 0.2
   - filter: Domain Check
@@ -35,8 +29,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  0.5]
   - filter: BlackList
     where:
     - variable:
@@ -57,3 +51,7 @@
         name: longitude@MetaData
       minvalue: 60
       maxvalue: 110
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001

--- a/soca/obs/adt_sa_egm2008.yaml
+++ b/soca/obs/adt_sa_egm2008.yaml
@@ -55,3 +55,7 @@
     where:
     - variable: { name: sea_ice_area_fraction@GeoVaLs}
       maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/adt_sa_egm2008.yaml
+++ b/soca/obs/adt_sa_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.1,
-                  2.0]
+          coefs: [0.5,
+                  3.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_sa_egm2008.yaml
+++ b/soca/obs/adt_sa_egm2008.yaml
@@ -35,8 +35,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  2.0]
   - filter: BlackList
     where:
     - variable:

--- a/soca/obs/adt_sa_egm2008.yaml
+++ b/soca/obs/adt_sa_egm2008.yaml
@@ -9,18 +9,12 @@
     name: ADT
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 500e3
   obs filters:
   - *obs_land_mask
   - filter: Domain Check
     where:
     - variable: { name: sea_surface_temperature@GeoVaLs}
-      minvalue: 5.0
+      minvalue: 15.0
   - filter: Background Check
     absolute threshold: 0.2
   - filter: Domain Check
@@ -35,8 +29,8 @@
         options:
           variables: [mesoscale_representation_error@GeoVaLs,
                       absolute_dynamic_topography@ObsError]
-          coefs: [0.5,
-                  3.0]
+          coefs: [0.1,
+                  0.5]
   - filter: BlackList
     where:
     - variable:
@@ -57,3 +51,7 @@
         name: longitude@MetaData
       minvalue: 60
       maxvalue: 110
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001

--- a/soca/obs/salt_profile_fnmoc.yaml
+++ b/soca/obs/salt_profile_fnmoc.yaml
@@ -42,3 +42,7 @@
     where:
     - variable: { name: sea_ice_area_fraction@GeoVaLs}
       maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/salt_profile_fnmoc.yaml
+++ b/soca/obs/salt_profile_fnmoc.yaml
@@ -26,5 +26,11 @@
   - filter: Bounds Check
     minvalue: 1.0
     maxvalue: 40.0
-#  - filter: Background Check
-#    threshold: 5.0
+  - filter: Background Check
+    threshold: 2.0
+  # Measurement errors are too small, inflate almost everywhere
+  #- filter: Background Check
+  #  threshold: 0.01
+  #  action:
+  #    name: inflate error
+  #    inflation factor: 30.0

--- a/soca/obs/salt_profile_fnmoc.yaml
+++ b/soca/obs/salt_profile_fnmoc.yaml
@@ -26,11 +26,5 @@
   - filter: Bounds Check
     minvalue: 1.0
     maxvalue: 40.0
-  - filter: Background Check
-    threshold: 2.0
-  # Measurement errors are too small, inflate almost everywhere
-  #- filter: Background Check
-  #  threshold: 0.01
-  #  action:
-  #    name: inflate error
-  #    inflation factor: 30.0
+#  - filter: Background Check
+#    threshold: 5.0

--- a/soca/obs/salt_profile_fnmoc.yaml
+++ b/soca/obs/salt_profile_fnmoc.yaml
@@ -34,3 +34,11 @@
   #  action:
   #    name: inflate error
   #    inflation factor: 30.0
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 3.0
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001

--- a/soca/obs/salt_profile_wod.yaml
+++ b/soca/obs/salt_profile_wod.yaml
@@ -1,14 +1,14 @@
 - obs space:
-    name: insitu_t_profile_fnmoc
+    name: insitu_s_profile_wod
     distribution:
       name: *obs_distribution
     obsdatain:
-      obsfile: $(experiment_dir)/{{current_cycle}}/temp_profile_fnmoc.{{window_begin}}.nc4
+      obsfile: $(experiment_dir)/{{current_cycle}}/salt_profile_wod.{{window_begin}}.nc4
     obsdataout:
-      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).temp_profile_fnmoc.{{window_begin}}.nc4
-    simulated variables: [sea_water_temperature]
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).salt_profile_wod.{{window_begin}}.nc4
+    simulated variables: [sea_water_salinity]
   obs operator:
-    name: InsituTemperature
+    name: MarineVertInterp
   obs error:
     covariance model: diagonal
   _letkf: &letkf
@@ -21,13 +21,13 @@
   - *obs_land_mask
   - filter: Domain Check
     where:
-    - variable: {name: sea_water_temperature@ObsError}
-      minvalue: 0.001
+    - variable: {name: sea_water_salinity@ObsError}
+      minvalue: 0.0001
   - filter: Bounds Check
-    minvalue: -2.0
-    maxvalue: 36.0
+    minvalue: 1.0
+    maxvalue: 40.0
   - filter: Background Check
-    threshold: 3.0
+    threshold: 2.0
   # Measurement errors are too small, inflate almost everywhere
   #- filter: Background Check
   #  threshold: 0.01
@@ -36,13 +36,13 @@
   #    inflation factor: 30.0
   - filter: Domain Check
     where:
-    - variable: { name: sea_ice_area_fraction@GeoVaLs}
-      maxvalue: 0.00001
-  - filter: Domain Check
-    where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 3.0
   - filter: Domain Check
     where:
-    - variable: {name: distance_from_coast@GeoVaLs}
-      minvalue: 100e3
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001
+#  - filter: Domain Check
+#    where:
+#    - variable: {name: distance_from_coast@GeoVaLs}
+#      minvalue: 100e3

--- a/soca/obs/salt_profile_wod.yaml
+++ b/soca/obs/salt_profile_wod.yaml
@@ -42,7 +42,3 @@
     where:
     - variable: { name: sea_ice_area_fraction@GeoVaLs}
       maxvalue: 0.00001
-#  - filter: Domain Check
-#    where:
-#    - variable: {name: distance_from_coast@GeoVaLs}
-#      minvalue: 100e3

--- a/soca/obs/sss_smap_jpl.yaml
+++ b/soca/obs/sss_smap_jpl.yaml
@@ -1,9 +1,9 @@
 - obs space:
-    name: sss_smap
+    name: sss_smap_jpl  
     obsdatain:
-      obsfile: $(experiment_dir)/{{current_cycle}}/sss_smap.{{window_begin}}.nc4
+      obsfile: $(experiment_dir)/{{current_cycle}}/sss_smap_jpl.{{window_begin}}.nc4
     obsdataout:
-      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sss_smap.{{window_begin}}.nc4
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).sss_smap_jpl.{{window_begin}}.nc4
     simulated variables: [sea_surface_salinity]
   obs operator:
     name: Identity
@@ -22,13 +22,17 @@
     maxvalue: 40.0
   - filter: Background Check
     threshold: 5.0
-  - filter: Domain Check
-    action:
-      name: passivate
-    where:
-    - variable: {name: sea_surface_temperature@GeoVaLs}
-      minvalue: 10.0
+#  - filter: Domain Check
+#    action:
+#      name: passivate
+#    where:
+#    - variable: {name: sea_surface_temperature@GeoVaLs}
+#      minvalue: 10.0
 
   ## Gaussian_Thinning is having problems with LETKF, try again later
   # - filter: Gaussian_Thinning
   #   horizontal_mesh:   25.0 #km
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sss_smap_jpl.yaml
+++ b/soca/obs/sss_smap_jpl.yaml
@@ -22,13 +22,6 @@
     maxvalue: 40.0
   - filter: Background Check
     threshold: 5.0
-#  - filter: Domain Check
-#    action:
-#      name: passivate
-#    where:
-#    - variable: {name: sea_surface_temperature@GeoVaLs}
-#      minvalue: 10.0
-
   ## Gaussian_Thinning is having problems with LETKF, try again later
   # - filter: Gaussian_Thinning
   #   horizontal_mesh:   25.0 #km

--- a/soca/obs/sss_smos.yaml
+++ b/soca/obs/sss_smos.yaml
@@ -34,3 +34,7 @@
   ## Gaussian_Thinning is having problems with LETKF, try again later
   # - filter: Gaussian_Thinning
   #   horizontal_mesh:   25.0 #km
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sss_trak_fnmoc.yaml
+++ b/soca/obs/sss_trak_fnmoc.yaml
@@ -30,3 +30,7 @@
     where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 10.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_amsr2_l3u.yaml
+++ b/soca/obs/sst_amsr2_l3u.yaml
@@ -33,3 +33,7 @@
     where:
     - variable: {name: sea_area_fraction@GeoVaLs}
       maxvalue: 0.9
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_drifter.yaml
+++ b/soca/obs/sst_drifter.yaml
@@ -36,3 +36,7 @@
       name: reject
     minvalue: -2.0
     maxvalue: 36.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_gmi_l3u.yaml
+++ b/soca/obs/sst_gmi_l3u.yaml
@@ -33,3 +33,7 @@
     where:
     - variable: {name: sea_area_fraction@GeoVaLs}
       maxvalue: 0.9
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_metopa_l3u_so025.yaml
+++ b/soca/obs/sst_metopa_l3u_so025.yaml
@@ -28,3 +28,7 @@
     where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 3.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_metopa_l3u_so025.yaml
+++ b/soca/obs/sst_metopa_l3u_so025.yaml
@@ -9,16 +9,10 @@
     name: Identity
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 500e3
   obs filters:
   - *obs_land_mask
   - filter: Bounds Check
-    minvalue: -2.0
+    minvalue: 1.0
     maxvalue: 36.0
   - filter: Background Check
     threshold: 5.0
@@ -26,3 +20,11 @@
     where:
     - variable: {name: sea_surface_temperature@ObsError}
       minvalue: 0.001
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 3.0

--- a/soca/obs/sst_metopb_l3u_so025.yaml
+++ b/soca/obs/sst_metopb_l3u_so025.yaml
@@ -30,3 +30,7 @@
     where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 3.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_metopb_l3u_so025.yaml
+++ b/soca/obs/sst_metopb_l3u_so025.yaml
@@ -11,16 +11,10 @@
     name: Identity
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 200e3
   obs filters:
   - *obs_land_mask
   - filter: Bounds Check
-    minvalue: -2.0
+    minvalue: 1.0
     maxvalue: 36.0
   - filter: Background Check
     threshold: 5.0
@@ -28,10 +22,11 @@
     where:
     - variable: {name: sea_surface_temperature@ObsError}
       minvalue: 0.001
-   #   maxvalue: 0.5
-    #action:
-    #  name: inflate error
-    #  inflation: 2.0
-  ## Gaussian_Thinning is having problems with the LETKF, try again alter
-  #- filter: Gaussian_Thinning
-  #  horizontal_mesh:  1111.949266 #km
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 3.0

--- a/soca/obs/sst_metopc_l3u_so025.yaml
+++ b/soca/obs/sst_metopc_l3u_so025.yaml
@@ -30,3 +30,7 @@
     where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 3.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_metopc_l3u_so025.yaml
+++ b/soca/obs/sst_metopc_l3u_so025.yaml
@@ -11,16 +11,10 @@
     name: Identity
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 200e3
   obs filters:
   - *obs_land_mask
   - filter: Bounds Check
-    minvalue: -2.0
+    minvalue: 1.0
     maxvalue: 36.0
   - filter: Background Check
     threshold: 5.0
@@ -28,10 +22,11 @@
     where:
     - variable: {name: sea_surface_temperature@ObsError}
       minvalue: 0.001
-    #  maxvalue: 0.5
-    #action:
-    #  name: inflate error
-    #  inflation: 2.0
-  ## Gaussian_Thinning is having problems with the LETKF, try again alter
-  #- filter: Gaussian_Thinning
-  #  horizontal_mesh:  1111.949266 #km
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 3.0

--- a/soca/obs/sst_noaa18_l3u_so025.yaml
+++ b/soca/obs/sst_noaa18_l3u_so025.yaml
@@ -28,3 +28,7 @@
     where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 3.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_noaa18_l3u_so025.yaml
+++ b/soca/obs/sst_noaa18_l3u_so025.yaml
@@ -9,16 +9,10 @@
     name: Identity
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 500e3
   obs filters:
   - *obs_land_mask
   - filter: Bounds Check
-    minvalue: -2.0
+    minvalue: 1.0
     maxvalue: 36.0
   - filter: Background Check
     threshold: 5.0
@@ -26,3 +20,11 @@
     where:
     - variable: {name: sea_surface_temperature@ObsError}
       minvalue: 0.001
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 3.0

--- a/soca/obs/sst_noaa19_l3u_so025.yaml
+++ b/soca/obs/sst_noaa19_l3u_so025.yaml
@@ -7,18 +7,10 @@
     simulated variables: [sea_surface_temperature]
   obs operator:
     name: Identity
-  obs error:
-    covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 500e3
   obs filters:
   - *obs_land_mask
   - filter: Bounds Check
-    minvalue: -2.0
+    minvalue: 1.0
     maxvalue: 36.0
   - filter: Background Check
     threshold: 5.0
@@ -26,3 +18,11 @@
     where:
     - variable: {name: sea_surface_temperature@ObsError}
       minvalue: 0.001
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 3.0

--- a/soca/obs/sst_noaa19_l3u_so025.yaml
+++ b/soca/obs/sst_noaa19_l3u_so025.yaml
@@ -26,3 +26,7 @@
     where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 3.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_ostia.yaml
+++ b/soca/obs/sst_ostia.yaml
@@ -28,10 +28,7 @@
     where:
     - variable: {name: sea_surface_temperature@ObsError}
       minvalue: 0.001
-   #   maxvalue: 0.5
-    #action:
-    #  name: inflate error
-    #  inflation: 2.0
-  ## Gaussian_Thinning is having problems with the LETKF, try again alter
-  #- filter: Gaussian_Thinning
-  #  horizontal_mesh:  1111.949266 #km
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001

--- a/soca/obs/sst_ostia.yaml
+++ b/soca/obs/sst_ostia.yaml
@@ -32,3 +32,7 @@
     where:
     - variable: { name: sea_ice_area_fraction@GeoVaLs}
       maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_ship_fnmoc.yaml
+++ b/soca/obs/sst_ship_fnmoc.yaml
@@ -38,3 +38,7 @@
       name: reject
     minvalue: -2.0
     maxvalue: 36.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_trak_fnmoc.yaml
+++ b/soca/obs/sst_trak_fnmoc.yaml
@@ -38,3 +38,7 @@
       name: reject
     minvalue: -2.0
     maxvalue: 36.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_viirs_n20_l3u_so025.yaml
+++ b/soca/obs/sst_viirs_n20_l3u_so025.yaml
@@ -30,3 +30,7 @@
     where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 3.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_viirs_n20_l3u_so025.yaml
+++ b/soca/obs/sst_viirs_n20_l3u_so025.yaml
@@ -11,16 +11,10 @@
     name: Identity
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 200e3
   obs filters:
   - *obs_land_mask
   - filter: Bounds Check
-    minvalue: -2.0
+    minvalue: 1.0
     maxvalue: 36.0
   - filter: Background Check
     threshold: 5.0
@@ -28,10 +22,11 @@
     where:
     - variable: {name: sea_surface_temperature@ObsError}
       minvalue: 0.001
-   #   maxvalue: 0.5
-    #action:
-    #  name: inflate error
-    #  inflation: 2.0
-  ## Gaussian_Thinning is having problems with the LETKF, try again alter
-  #- filter: Gaussian_Thinning
-  #  horizontal_mesh:  1111.949266 #km
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 3.0

--- a/soca/obs/sst_viirs_npp_l3u_so025.yaml
+++ b/soca/obs/sst_viirs_npp_l3u_so025.yaml
@@ -30,3 +30,7 @@
     where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 3.0
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/sst_viirs_npp_l3u_so025.yaml
+++ b/soca/obs/sst_viirs_npp_l3u_so025.yaml
@@ -11,16 +11,10 @@
     name: Identity
   obs error:
     covariance model: diagonal
-  _letkf: &letkf
-    # note, this is only used for LETKF. If running with LETKF, the workflow
-    # will append "<< : *letkf" to the end of this file
-    obs localizations:
-    - localization method: Horizontal Gaspari-Cohn
-      lengthscale: 200e3
   obs filters:
   - *obs_land_mask
   - filter: Bounds Check
-    minvalue: -2.0
+    minvalue: 1.0
     maxvalue: 36.0
   - filter: Background Check
     threshold: 5.0
@@ -28,10 +22,11 @@
     where:
     - variable: {name: sea_surface_temperature@ObsError}
       minvalue: 0.001
-   #   maxvalue: 0.5
-    #action:
-    #  name: inflate error
-    #  inflation: 2.0
-  ## Gaussian_Thinning is having problems with the LETKF, try again alter
-  #- filter: Gaussian_Thinning
-  #  horizontal_mesh:  1111.949266 #km
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 3.0

--- a/soca/obs/sst_windsat_l3u.yaml
+++ b/soca/obs/sst_windsat_l3u.yaml
@@ -33,3 +33,7 @@
     where:
     - variable: {name: sea_area_fraction@GeoVaLs}
       maxvalue: 0.9
+  - filter: Domain Check
+    where:
+    - variable: {name: distance_from_coast@GeoVaLs}
+      minvalue: 100e3

--- a/soca/obs/temp_profile_fnmoc.yaml
+++ b/soca/obs/temp_profile_fnmoc.yaml
@@ -34,4 +34,12 @@
   #  action:
   #    name: inflate error
   #    inflation factor: 30.0
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_ice_area_fraction@GeoVaLs}
+      maxvalue: 0.00001
+  - filter: Domain Check
+    where:
+    - variable: {name: sea_surface_temperature@GeoVaLs}
+      minvalue: 3.0
 

--- a/soca/obs/temp_profile_fnmoc.yaml
+++ b/soca/obs/temp_profile_fnmoc.yaml
@@ -26,12 +26,5 @@
   - filter: Bounds Check
     minvalue: -2.0
     maxvalue: 36.0
-  - filter: Background Check
-    threshold: 3.0
-  # Measurement errors are too small, inflate almost everywhere
-  #- filter: Background Check
-  #  threshold: 0.01
-  #  action:
-  #    name: inflate error
-  #    inflation factor: 30.0
-
+#  - filter: Background Check
+#    threshold: 5.0

--- a/soca/obs/temp_profile_fnmoc.yaml
+++ b/soca/obs/temp_profile_fnmoc.yaml
@@ -26,5 +26,12 @@
   - filter: Bounds Check
     minvalue: -2.0
     maxvalue: 36.0
-#  - filter: Background Check
-#    threshold: 5.0
+  - filter: Background Check
+    threshold: 3.0
+  # Measurement errors are too small, inflate almost everywhere
+  #- filter: Background Check
+  #  threshold: 0.01
+  #  action:
+  #    name: inflate error
+  #    inflation factor: 30.0
+

--- a/soca/obs/temp_profile_wod.yaml
+++ b/soca/obs/temp_profile_wod.yaml
@@ -42,7 +42,3 @@
     where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 3.0
-#  - filter: Domain Check
-#    where:
-#    - variable: {name: distance_from_coast@GeoVaLs}
-#      minvalue: 100e3

--- a/soca/obs/temp_profile_wod.yaml
+++ b/soca/obs/temp_profile_wod.yaml
@@ -1,11 +1,11 @@
 - obs space:
-    name: insitu_t_profile_fnmoc
+    name: insitu_t_profile_wod
     distribution:
       name: *obs_distribution
     obsdatain:
-      obsfile: $(experiment_dir)/{{current_cycle}}/temp_profile_fnmoc.{{window_begin}}.nc4
+      obsfile: $(experiment_dir)/{{current_cycle}}/temp_profile_wod.{{window_begin}}.nc4
     obsdataout:
-      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).temp_profile_fnmoc.{{window_begin}}.nc4
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).temp_profile_wod.{{window_begin}}.nc4
     simulated variables: [sea_water_temperature]
   obs operator:
     name: InsituTemperature
@@ -42,7 +42,7 @@
     where:
     - variable: {name: sea_surface_temperature@GeoVaLs}
       minvalue: 3.0
-  - filter: Domain Check
-    where:
-    - variable: {name: distance_from_coast@GeoVaLs}
-      minvalue: 100e3
+#  - filter: Domain Check
+#    where:
+#    - variable: {name: distance_from_coast@GeoVaLs}
+#      minvalue: 100e3

--- a/soca/soca_3dvar.yaml
+++ b/soca/soca_3dvar.yaml
@@ -113,8 +113,8 @@ cost function:
         ssh_min: 0.0   # value at EQ
         ssh_max: 0.0   # value in Extratropics
         ssh_phi_ex: 20 # lat of transition from extratropics
-        cicen_min: 0.1
-        cicen_max: 0.1
+        cicen_min: 0.05
+        cicen_max: 0.05
         hicen_min: 0.1
         hicen_max: 0.1
 

--- a/soca/soca_3dvar.yaml
+++ b/soca/soca_3dvar.yaml
@@ -71,30 +71,30 @@ cost function:
     state variables: [__DA_VARIABLES__, mld, layer_depth]
 
   background error:
-    covariance model: SABER
-    saber blocks:
-    - saber block name: ID
-      input variables: *soca_vars
-      output variables: *soca_vars
+#    covariance model: SABER
+#    saber blocks:
+#    - saber block name: ID
+#      input variables: *soca_vars
+#      output variables: *soca_vars
 
-#    covariance model: SocaError
-#    analysis variables: [__DA_VARIABLES__]
-#    date: *bkg_date
-#    bump:
-#      verbosity: main
-#      datadir: ./bump
-#      strategy: specific_univariate
-#      load_nicas_local: true
-#    correlation: *corr_list___DOMAINS__
+    covariance model: SocaError
+    analysis variables: [__DA_VARIABLES__]
+    date: *bkg_date
+    bump:
+      verbosity: main
+      datadir: ./bump
+      strategy: specific_univariate
+      load_nicas_local: true
+    correlation: *corr_list___DOMAINS__
 
     linear variable change:
       input variables: *soca_vars
       output variables: *soca_vars
       linear variable changes:
 
-      - linear variable change name: HorizFiltSOCA
-        niter: 2
-        filter variables: *soca_vars
+#      - linear variable change name: HorizFiltSOCA
+#        niter: 6
+#        filter variables: *soca_vars
 
       - linear variable change name: VertConvSOCA
         Lz_min: 0.0

--- a/soca/soca_3dvar.yaml
+++ b/soca/soca_3dvar.yaml
@@ -71,26 +71,30 @@ cost function:
     state variables: [__DA_VARIABLES__, mld, layer_depth]
 
   background error:
-    #covariance model: SABER
-    #saber blocks:
-    #- saber block name: ID
-    #  input variables: *soca_vars
-    #  output variables: *soca_vars
+    covariance model: SABER
+    saber blocks:
+    - saber block name: ID
+      input variables: *soca_vars
+      output variables: *soca_vars
 
-    covariance model: SocaError
-    analysis variables: [__DA_VARIABLES__]
-    date: *bkg_date
-    bump:
-      verbosity: main
-      datadir: ./bump
-      strategy: specific_univariate
-      load_nicas_local: true
-    correlation: *corr_list___DOMAINS__
+#    covariance model: SocaError
+#    analysis variables: [__DA_VARIABLES__]
+#    date: *bkg_date
+#    bump:
+#      verbosity: main
+#      datadir: ./bump
+#      strategy: specific_univariate
+#      load_nicas_local: true
+#    correlation: *corr_list___DOMAINS__
 
     linear variable change:
       input variables: *soca_vars
       output variables: *soca_vars
       linear variable changes:
+
+      - linear variable change name: HorizFiltSOCA
+        niter: 2
+        filter variables: *soca_vars
 
       - linear variable change name: VertConvSOCA
         Lz_min: 0.0

--- a/soca/soca_staticbinit.yaml
+++ b/soca/soca_staticbinit.yaml
@@ -11,8 +11,8 @@ _corr:
   - &corr_ocn
     name: ocn
     rossby mult: 1.0
-    min grid mult: 2.0
-    min value: 50.0e3
+    min grid mult: 3.0
+    min value: 100.0e3
     variables: [__DA_VARIABLES_OCN__]
   - &corr_ice
     name: ice

--- a/soca/soca_staticbinit.yaml
+++ b/soca/soca_staticbinit.yaml
@@ -11,8 +11,8 @@ _corr:
   - &corr_ocn
     name: ocn
     rossby mult: 1.0
-    min grid mult: 3.0
-    min value: 100.0e3
+    min grid mult: 1.0
+    min value: 50.0e3
     variables: [__DA_VARIABLES_OCN__]
   - &corr_ice
     name: ice


### PR DESCRIPTION
## Description
A distance to coastal filter is added to all observation yaml files. For 0.25 deg simulation the minimum value could be 100 km but for low resolution such as 1 deg, the minimum distance could be 200 km or more so that it covers few grids.  


### Issue(s) addressed

- fixes #281 


## Testing
This filter has been tested with soca ctest using the command
```
srun -n 2 ./bin/soca_var.x yaml-file
```
We then test this filter using realistic observation. The output clearly shows that the filter is able to remove the observation near the coast depending on the distance.


