### PR TITLE
Feature/3dbump

### DIFF
--- a/soca/soca_3dvar.yaml
+++ b/soca/soca_3dvar.yaml
@@ -71,36 +71,29 @@ cost function:
     state variables: [__DA_VARIABLES__, mld, layer_depth]
 
   background error:
-#    covariance model: SABER
-#    saber blocks:
-#    - saber block name: ID
-#      input variables: *soca_vars
-#      output variables: *soca_vars
 
-    covariance model: SocaError
-    analysis variables: [__DA_VARIABLES__]
-    date: *bkg_date
-    bump:
-      verbosity: main
-      datadir: ./bump
-      strategy: specific_univariate
-      load_nicas_local: true
-    correlation: *corr_list___DOMAINS__
+    covariance model: SABER
+    saber blocks:
+    - saber block name: BUMP_NICAS
+      saber central block: true
+      iterative inverse: true
+      input variables: *soca_vars
+      output variables: *soca_vars
+      bump:
+        verbosity: main
+        datadir: ./bump
+        strategy: specific_univariate
+        load_nicas_local: true
+        grids:
+        - prefix: bump3d
+          variables: [hocn, socn, tocn]
+        - prefix: bump2d
+          variables: [ssh, cicen, hicen, hsnon]
 
     linear variable change:
       input variables: *soca_vars
       output variables: *soca_vars
       linear variable changes:
-
-#      - linear variable change name: HorizFiltSOCA
-#        niter: 6
-#        filter variables: *soca_vars
-
-      - linear variable change name: VertConvSOCA
-        Lz_min: 0.0
-        Lz_mld: 0
-        Lz_mld_max: 1.0
-        scale_layer_thick: 5
 
       - linear variable change name: BkgErrFILT
         ocean_depth_min: 0    # [m]
@@ -128,4 +121,5 @@ cost function:
         dtdzmin: 1.0e-6
         nlayers: 10
 
-  observations: *observations
+  observations:
+    observers: *observations

--- a/soca/soca_bump3dinit.yaml
+++ b/soca/soca_bump3dinit.yaml
@@ -1,0 +1,47 @@
+geometry:
+  geom_grid_file: soca_gridspec.nc
+  mom6_input_nml: mom_input.nml
+  fields metadata: ./fields_metadata.yaml
+
+input variables: [socn, tocn, ssh, hocn, hsnon, hicen, cicen]
+
+background:
+  read_from_file: 1
+  date: &date 2019-08-31T12:00:00Z
+  basename: ./RESTART_IN/
+  ocn_filename: MOM.res.nc
+  ice_filename: cice.res.nc
+  state variables: [socn, tocn, ssh, hocn, hsnon, hicen, cicen]
+
+bump:
+  verbosity: main
+  datadir: ./bump
+  method: cor
+  strategy: specific_univariate
+  new_nicas: true
+  write_nicas_local: true
+  mask_check: false #true
+  resol: 20.0
+  network: false # Not re-implemented yet
+  nc1max: 88000
+  grids:
+  - prefix: bump3d
+    variables: [socn, tocn, hocn]
+  - prefix: bump2d
+    variables: [ssh, hsnon, hicen, cicen]
+
+  input:
+  - parameter: rh
+    read_from_file: 1
+    date: *date
+    basename: ./
+    ocn_filename: ocn.cor_rh.incr.2019-08-31T12:00:00Z.nc
+    ice_filename: ice.cor_rh.incr.2019-08-31T12:00:00Z.nc
+    state variables: [socn, tocn, ssh, hocn, hsnon, hicen, cicen]
+  - parameter: rv
+    read_from_file: 1
+    date: *date
+    basename: ./
+    ocn_filename: ocn.cor_rv.incr.2019-08-31T12:00:00Z.nc
+    ice_filename: ice.cor_rv.incr.2019-08-31T12:00:00Z.nc
+    state variables: [socn, tocn, ssh, hocn, hsnon, hicen, cicen]

--- a/soca/soca_bump3dinit.yaml
+++ b/soca/soca_bump3dinit.yaml
@@ -21,7 +21,7 @@ bump:
   new_nicas: true
   write_nicas_local: true
   mask_check: false #true
-  resol: 20.0
+  resol: 10.0
   network: false # Not re-implemented yet
   nc1max: 88000
   grids:

--- a/soca/soca_setcorscales.yaml
+++ b/soca/soca_setcorscales.yaml
@@ -1,0 +1,44 @@
+resolution:
+  mom6_input_nml: mom_input.nml
+  fields metadata: ./fields_metadata.yaml
+
+date: 2019-08-31T12:00:00Z
+
+corr variables: [socn, tocn, ssh, hocn, cicen, hicen, hsnon]
+
+scales:
+  vert layers: 5 # in units of layer
+  socn:
+    rossby mult: 0.28
+    min grid mult: 0.28
+  tocn:
+    rossby mult: 0.28
+    min grid mult: 0.28
+  hocn:
+    rossby mult: 100.0
+    min grid mult: 100.0
+  ssh:
+    rossby mult: 0.28
+    min grid mult: 0.28
+  cicen:
+    rossby mult: 0.0
+    min grid mult: 1.0
+    min: 50.0
+  hicen:
+    rossby mult: 0.0
+    min grid mult: 1.0
+    min: 150.0
+  hsnon:
+    rossby mult: 0.0
+    min grid mult: 1.0
+    min: 1000.0
+
+rh output:
+  datadir: ./
+  exp: cor_rh
+  type: incr
+
+rv output:
+  datadir: ./
+  exp: cor_rv
+  type: incr

--- a/soca/soca_staticbinit.yaml
+++ b/soca/soca_staticbinit.yaml
@@ -12,7 +12,8 @@ _corr:
     name: ocn
     rossby mult: 1.0
     min grid mult: 1.0
-    min value: 50.0e3
+    min value: 0.0e3
+    max value: 150.0e3
     variables: [__DA_VARIABLES_OCN__]
   - &corr_ice
     name: ice
@@ -46,6 +47,6 @@ background error:
     new_nicas: true
     write_nicas_local: true
     mask_check: true
-    resol: 10.0
+    resol: 20.0
     nc1max: 88000
   correlation: *corr_list___DOMAINS__


### PR DESCRIPTION
## Description
Addition of 3 yaml files to allow using BUMP_NICAS (bump3d).

- `soca_setcorscales.yaml`: Set the parameters that define the horizontal and vertical Gaspari-Cohn function
- `soca/soca_bump3dinit.yaml`: config file for `soca_error_covariance_training.x`. Will compute the convolution weights (slow) 
- `soca/soca_3dvar_3dbump.yaml`: A bit silly, same as the 3dvar yaml but with hard-coded variables and making use of a `saber block` for **C**

### Issue(s) addressed
- fixes #340 

## Dependencies
Needs [soca-science #486](https://github.com/JCSDA-internal/soca-science/pull/486)

