### PR TITLE
'BGC-ify' this repo

### DIFF
--- a/soca/obs/oc_aqua.yaml
+++ b/soca/obs/oc_aqua.yaml
@@ -1,0 +1,35 @@
+- obs space:
+    name: oc_aqua
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/oc_aqua.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).oc_aqua.{{window_begin}}.nc4
+    simulated variables: [sea_surface_chlorophyll]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Gaussian_Thinning
+    horizontal_mesh:   11
+    use_reduced_horizontal_grid: false
+  - filter: Bounds Check
+    minvalue: 0.001
+    maxvalue: 30.0
+  - filter: BlackList
+    where:
+    - variable:
+        name: sea_surface_chlorophyll@PreQC
+      any_bit_set_of: 0,1,3,4,5,8,9,10,12,14,15,16,19,21,22,25
+    action:
+      name: inflate error
+      inflation factor: 1.5

--- a/soca/obs/oc_dineof3.yaml
+++ b/soca/obs/oc_dineof3.yaml
@@ -1,0 +1,35 @@
+- obs space:
+    name: oc_dineof3
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/oc_dineof3.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).oc_dineof3.{{window_begin}}.nc4
+    simulated variables: [sea_surface_chlorophyll]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Gaussian_Thinning
+    horizontal_mesh:   11
+    use_reduced_horizontal_grid: false
+  - filter: Bounds Check
+    minvalue: 0.001
+    maxvalue: 30.0
+  - filter: BlackList
+    where:
+    - variable:
+        name: sea_surface_chlorophyll@PreQC
+      any_bit_set_of: 0,1,3,4,5,8,9,10,12,14,15,16,19,21,22,25
+    action:
+      name: inflate error
+      inflation factor: 1.5

--- a/soca/obs/oc_noaa20.yaml
+++ b/soca/obs/oc_noaa20.yaml
@@ -1,0 +1,35 @@
+- obs space:
+    name: oc_noaa20
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/oc_noaa20.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).oc_noaa20.{{window_begin}}.nc4
+    simulated variables: [sea_surface_chlorophyll]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Gaussian_Thinning
+    horizontal_mesh:   11
+    use_reduced_horizontal_grid: false
+  - filter: Bounds Check
+    minvalue: 0.001
+    maxvalue: 30.0
+  - filter: BlackList
+    where:
+    - variable:
+        name: sea_surface_chlorophyll@PreQC
+      any_bit_set_of: 0,1,3,4,5,8,9,10,12,14,15,16,19,21,22,25
+    action:
+      name: inflate error
+      inflation factor: 1.5

--- a/soca/obs/oc_snpp.yaml
+++ b/soca/obs/oc_snpp.yaml
@@ -1,0 +1,35 @@
+- obs space:
+    name: oc_snpp
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      obsfile: $(experiment_dir)/{{current_cycle}}/oc_snpp.{{window_begin}}.nc4
+    obsdataout:
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).oc_snpp.{{window_begin}}.nc4
+    simulated variables: [sea_surface_chlorophyll]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  _letkf: &letkf
+    # note, this is only used for LETKF. If running with LETKF, the workflow
+    # will append "<< : *letkf" to the end of this file
+    obs localizations:
+    - localization method: Horizontal Gaspari-Cohn
+      lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Gaussian_Thinning
+    horizontal_mesh:   11
+    use_reduced_horizontal_grid: false
+  - filter: Bounds Check
+    minvalue: 0.001
+    maxvalue: 30.0
+  - filter: BlackList
+    where:
+    - variable:
+        name: sea_surface_chlorophyll@PreQC
+      any_bit_set_of: 0,1,3,4,5,8,9,10,12,14,15,16,19,21,22,25
+    action:
+      name: inflate error
+      inflation factor: 1.5

--- a/soca/soca_3dvar.yaml
+++ b/soca/soca_3dvar.yaml
@@ -117,6 +117,10 @@ cost function:
         ssh_min: 0.0   # value at EQ
         ssh_max: 0.0   # value in Extratropics
         ssh_phi_ex: 20 # lat of transition from extratropics
+        chl_min: 0.003
+        chl_max: 10.0
+        biop_min: 0.0
+        biop_max: 1.0e-6
         cicen_min: 0.05
         cicen_max: 0.05
         hicen_min: 0.1

--- a/soca/soca_checkpoint_ocn_bgc.yaml
+++ b/soca/soca_checkpoint_ocn_bgc.yaml
@@ -1,0 +1,8 @@
+# Parameters used in ocean bgc checkpoint and balance utils
+cpcoefs:
+  chl_max:     20.0      # Maximum chl analysis (checkpoints after maxfac and minfac are applied)
+  chl_min:    0.001      # Mininum chl analysis (checkpoints after maxfac and minfac are applied)
+  po4_max:     3.0e-6    # Maximum po4 analysis (checkpoints after maxfac and minfac are applied)
+  irr_mix_min: 1.0       # Only apply the analysis for po4 where irr_mix is greater than this value
+  maxfac:      2.0       # maximum analysis value is set to be maxfac * bkg value
+  minfac:      0.5       # mininum analysis value is set to be minfac * bkg value


### PR DESCRIPTION
## Description
The current repo is missing most of the stuff required for to run `soca-science` with BGC (`ecbuild -DENABLE_OCEAN_BGC=ON`), if set as `SOCA_DEFAULT_CFGS_DIR`. In this PR we:

1. add obs yamls for a few satellite sensors.
2. update `soca_3dvar.yaml` to apply bkgerr bounds under `- linear variable change name: BkgErrGODAS` for BGC states.
3. add the yaml required to run BGC checkpoint in run.var step.

### Issue(s) addressed
- fixes #350 


