### PR TITLE
convert RTOFS obs binary to IODA v2

### DIFF
--- a/obsproc/rtofs/Makefile
+++ b/obsproc/rtofs/Makefile
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ifort read_ssh.F90 -O2 -fpp -traceback -xHost -fno-alias -fp-model strict -no-fma -ftz -mkl -DLINUX -convert big_endian -assume byterecl -fixed -real_size 32 -i4 -o read_ssh.exe
+
+ifort read_sss.F90 -O2 -fpp -traceback -xHost -fno-alias -fp-model strict -no-fma -ftz -mkl -DLINUX -convert big_endian -assume byterecl -fixed -real_size 32 -i4 -o read_sss.exe
+
+ifort read_sst.F90 -O2 -fpp -traceback -xHost -fno-alias -fp-model strict -no-fma -ftz -mkl -DLINUX -convert big_endian -assume byterecl -fixed -real_size 32 -i4 -o read_sst.exe
+
+ifort read_profile.F90 -O2 -fpp -traceback -xHost -fno-alias -fp-model strict -no-fma -ftz -mkl -DLINUX -convert big_endian -assume byterecl -fixed -real_size 32 -i4 -o read_profile.exe
+

--- a/obsproc/rtofs/README.md
+++ b/obsproc/rtofs/README.md
@@ -1,0 +1,10 @@
+
+Purpose: convert RTOFS operational obs binary to IODA V2
+
+(1) Extract RTOFS obs binary data from HPSS, e.g., 
+module load hpss
+htar -xv -f /NCEPDEV/emc-ocean/5year/emc.ncodapa/emc_parallel/ncoda.20210211/ocnqc.tar 
+
+(2) Shell scripts orgnize data files, call Fortran programs and python scripts to convert RTOFS bin to IODA v2. Fortran codes read RTOFS bin and write ascii. python scripts read ascii and write IODA v2.
+
+

--- a/obsproc/rtofs/read_profile.F90
+++ b/obsproc/rtofs/read_profile.F90
@@ -1,0 +1,169 @@
+      program read_profile
+c     implicit none
+c
+c     ..define maximum number daily files
+c
+      integer    MX_FILES
+      parameter (MX_FILES = 300)
+c
+      integer    UNIT
+      parameter (UNIT = 20)
+c
+      integer   n_depth
+      integer   n_prf
+      parameter(n_depth=2500, n_prf=7500)
+
+c
+      character winstart *12, winend *12
+      logical   exist
+      character file_dtg (MX_FILES) * 10
+      character file_name * 256
+      integer   i, j
+      integer   len
+      integer   len_data
+      integer   mx_depth
+      integer   mx_obs
+      integer   n_dup
+      integer   n_files
+      integer   n_in
+      integer   n_lev
+      integer   n_out
+      integer   n_rpl
+      logical   new_file
+      integer   old_vrsn
+      real      qc_lmt
+      integer   total
+      integer   vrsn
+
+      real      clm_sal (n_depth, n_prf)
+      real      clm_sstd (n_depth, n_prf)
+      real      clm_tmp (n_depth, n_prf)
+      real      clm_tstd (n_depth, n_prf)
+      logical   dup_prf (n_prf)
+      real      prf_btm (n_prf)
+c     character prf_dtg (n_prf) * 12
+      integer   ob_flg (n_depth, n_prf)
+c     real      prf_lat (n_prf)
+      real      prf_lon (n_prf)
+      integer   prf_ls (n_prf)
+c      integer   prf_lt (n_prf)
+      integer,  allocatable :: prf_lt (:)
+c     real      prf_lvl (n_depth, n_prf)
+      character,allocatable :: prf_dtg (:) * 12
+      real,     allocatable :: prf_lat (:)
+      real,     allocatable :: prf_lvl (:,:)
+      character prf_rcpt (n_prf) * 12
+      integer   prf_rej (n_depth, n_prf)
+      real      prf_sal (n_depth, n_prf)
+      real      prf_sal_err (n_depth, n_prf)
+      integer   prf_sal_typ (n_prf)
+      character prf_sgn (n_prf) * 7
+      real      prf_sprb (n_depth, n_prf)
+
+      character prf_csal (n_depth, n_prf) * 7
+      real      prf_cssd (n_depth, n_prf)
+      character prf_ctmp (n_depth, n_prf) * 7
+      real      prf_ctsd (n_depth, n_prf)
+
+      real      prf_sqc (n_prf)
+      real      prf_tmp (n_depth, n_prf)
+      real      prf_tmp_err (n_depth, n_prf)
+      integer   prf_tmp_typ (n_prf)
+      real      prf_tprb (n_depth, n_prf)
+      real      prf_tqc (n_prf)
+      real      prf_rct (n_prf)
+
+      open (UNIT, file='profile.bin', status='old',
+     6      form='unformatted')
+
+      read (UNIT) n_in, n_lev, old_vrsn
+      write(*,*) ' n_in, n_lev, old_vrsn',  n_in, n_lev, old_vrsn
+
+      if (n_in .gt. 0) then
+      allocate (prf_lat (n_in))
+      allocate (prf_dtg (n_in))
+      allocate (prf_lt (n_in))
+      allocate (prf_lvl (n_lev, n_in))
+
+      read (unit) prf_btm(1:n_in)
+      read (unit) prf_lat(1:n_in)
+      read (unit) prf_lon(1:n_in)
+      read (unit) prf_ls(1:n_in)
+      read (unit) prf_lt(1:n_in)
+      read (unit) prf_sal_typ(1:n_in)
+      read (unit) prf_sqc(1:n_in)
+      read (unit) prf_tmp_typ(1:n_in)
+      read (unit) prf_tqc(1:n_in)
+
+      do i = 1, n_in
+         read (unit) prf_lvl(1:prf_lt(i),i)
+         read (unit) prf_sal(1:prf_lt(i),i)
+         read (unit) prf_sal_err(1:prf_lt(i),i)
+         read (unit) prf_sprb(1:prf_lt(i),i)
+         read (unit) prf_tmp(1:prf_lt(i),i)
+         read (unit) prf_tmp_err(1:prf_lt(i),i)
+         read (unit) prf_tprb(1:prf_lt(i),i)
+         read (UNIT) ob_clm_sal
+         read (unit) prf_cssd(1:prf_lt(i),i)
+         read (UNIT) ob_clm_tmp
+         read (unit) prf_ctsd(1:prf_lt(i),i)
+         read (unit) ob_flg(1:prf_lt(i),i)
+      enddo
+
+      read (unit) prf_dtg(1:n_in)
+      read (unit) prf_rct(1:n_in)
+      read (unit) prf_sgn(1:n_in)
+
+      close (unit)
+
+      endif
+
+      open(21,file='window.txt',status='old')
+      read(21,'(a12)') winstart
+      read(21,'(a12)') winend
+      close(21)
+
+      open(20,file='profile.txt',status='unknown')
+
+      do i=1, n_in
+
+!     HAT10
+      if(prf_lat(i).ge.1.0.and.prf_lat(i).le.50.0.and.
+     6   prf_lon(i).ge.-100.0.and.prf_lon(i).le.-7.0) then
+
+!     time window
+      if(prf_dtg(i).ge.winstart.and.prf_dtg(i).le.winend) then
+
+      if(prf_tqc(i).gt.99.0) then
+         prf_tqc(i)=99.9
+      endif
+
+      if(prf_sqc(i).gt.99.0) then
+         prf_sqc(i)=99.9
+      endif
+
+!     profile
+      do j=1, prf_lt(i)
+
+      if(prf_sal_err(j,i).eq.-999.0) then
+      prf_sal_err(j,i)=1.0
+      endif
+
+      write(20,25) prf_dtg(i),prf_lat(i),prf_lon(i),
+     6             prf_tmp(j,i),prf_tmp_err(j,i),prf_tqc(i),
+     6             prf_sal(j,i),prf_sal_err(j,i),prf_sqc(i),
+     6             prf_lvl(j,i)
+
+      enddo ! profile
+
+      endif ! time window
+
+      endif ! HAT10
+
+      enddo
+
+25    format(a12,1x,f6.3,1x,f8.3,6(1x,f6.3),1x,f6.1)
+      close(20)
+
+      stop
+      end

--- a/obsproc/rtofs/read_ssh.F90
+++ b/obsproc/rtofs/read_ssh.F90
@@ -1,0 +1,90 @@
+      program read_ssh
+        
+      integer   n_lvl
+      integer   n_read
+      integer   vrsn
+
+      real,     allocatable :: ob_age (:)
+      integer,  allocatable :: ob_cyc (:)
+      character,allocatable :: ob_dtg (:) * 14
+      real,     allocatable :: ob_lat (:)
+      real,     allocatable :: ob_lon (:)
+      real,     allocatable :: ob_qc (:)
+      integer,  allocatable :: ob_ltc (:)
+      character,allocatable :: ob_rcpt (:) * 14
+      integer,  allocatable :: ob_sat (:)
+      integer,  allocatable :: ob_smpl (:)
+      real,     allocatable :: ob_ssh (:)
+      integer,  allocatable :: ob_trck (:) 
+        
+      character winstart *14, winend *14
+
+      open(10,file='ssh.bin',form='unformatted')
+
+      write(*,*) 'reading SST'
+
+      read (10) n_read, n_lvl, vrsn
+
+      if (n_read .gt. 0) then
+
+      allocate (ob_age(n_read))
+      allocate (ob_cyc(n_read))
+      allocate (ob_lat(n_read))
+      allocate (ob_lon(n_read))
+      allocate (ob_qc(n_read))
+      allocate (ob_sat(n_read))
+      allocate (ob_smpl(n_read))
+      allocate (ob_ssh(n_read))
+      allocate (ob_trck(n_read))
+      allocate (ob_ltc(n_read))
+      allocate (ob_dtg(n_read))
+      allocate (ob_rcpt(n_read))
+
+      read (10) ob_age(1:n_read)
+      read (10) ob_cyc(1:n_read)
+      read (10) ob_lat(1:n_read)
+      read (10) ob_lon(1:n_read)
+      read (10) ob_qc(1:n_read)
+      read (10) ob_sat(1:n_read)
+      read (10) ob_smpl(1:n_read)
+      read (10) ob_ssh(1:n_read)
+      read (10) ob_trck(1:n_read)
+      read (10) ob_ltc(1:n_read)
+      read (10) ob_dtg(1:n_read)
+      read (10) ob_rcpt(1:n_read)
+
+      open(21,file='window.txt',status='old')
+      read(21,'(a14)') winstart
+      read(21,'(a14)') winend
+      close(21)
+
+      open(20,file='ssh.txt',status='unknown')
+        
+      do i=1, n_read
+
+!     HAT10
+      if(ob_lat(i).ge.1.0.and.ob_lat(i).le.50.0.and.
+     6   ob_lon(i).ge.-100.0.and.ob_lon(i).le.-7.0) then
+
+!     time window
+      if(ob_dtg(i).ge.winstart.and.ob_dtg(i).le.winend) then
+
+      if(ob_dtg(i)(13:14).gt."59") ob_dtg(i)(13:14)="59"
+      if(ob_dtg(i)(11:12).gt."59") ob_dtg(i)(11:12)="59"
+
+      write(20,25) ob_dtg(i)(1:12),ob_lat(i),ob_lon(i),
+     6             ob_ssh(i),0.1,ob_qc(i)
+
+      endif ! End of time window
+      endif ! End of HAT10
+
+      enddo
+
+25    format(a12,1x,f6.3,1x,f8.3,3(1x,f6.3))
+      close(20)
+
+      endif
+
+      stop
+      end
+

--- a/obsproc/rtofs/read_ssh.F90
+++ b/obsproc/rtofs/read_ssh.F90
@@ -17,7 +17,7 @@
       real,     allocatable :: ob_ssh (:)
       integer,  allocatable :: ob_trck (:) 
         
-      character winstart *14, winend *14
+      character winstart *12, winend *12
 
       open(10,file='ssh.bin',form='unformatted')
 
@@ -54,8 +54,8 @@
       read (10) ob_rcpt(1:n_read)
 
       open(21,file='window.txt',status='old')
-      read(21,'(a14)') winstart
-      read(21,'(a14)') winend
+      read(21,'(a12)') winstart
+      read(21,'(a12)') winend
       close(21)
 
       open(20,file='ssh.txt',status='unknown')
@@ -67,7 +67,8 @@
      6   ob_lon(i).ge.-100.0.and.ob_lon(i).le.-7.0) then
 
 !     time window
-      if(ob_dtg(i).ge.winstart.and.ob_dtg(i).le.winend) then
+      if(ob_dtg(i)(1:12).ge.winstart.and.ob_dtg(i)(1:12).le.
+     6   winend) then
 
       if(ob_dtg(i)(13:14).gt."59") ob_dtg(i)(13:14)="59"
       if(ob_dtg(i)(11:12).gt."59") ob_dtg(i)(11:12)="59"

--- a/obsproc/rtofs/read_sss.F90
+++ b/obsproc/rtofs/read_sss.F90
@@ -1,0 +1,95 @@
+      program read_sss
+
+      real,     allocatable :: ob_age (:)
+      character,allocatable :: ob_dtg (:) * 12
+      real,     allocatable :: ob_err (:)
+      integer,  allocatable :: ob_flg (:)
+      real,     allocatable :: ob_lat (:)
+      real,     allocatable :: ob_lon (:)
+      real,     allocatable :: ob_qc (:)
+      character,allocatable :: ob_rcp (:) * 12
+      real,     allocatable :: ob_sss (:)
+      real,     allocatable :: ob_sst (:)
+      integer,  allocatable :: ob_typ (:)
+c
+      character winstart *12, winend *12
+      integer n_read, n_lvl, vrsn, i
+c
+      open(10,file='sss.bin',form='unformatted')
+
+      write(*,*) 'reading RTOFS binary SSS'
+
+      read (10) n_read, n_lvl, vrsn
+      if (n_read .gt. 0) then
+c
+      allocate (ob_age (n_read))
+      allocate (ob_dtg (n_read))
+      allocate (ob_err (n_read))
+      allocate (ob_flg (n_read))
+      allocate (ob_lat (n_read))
+      allocate (ob_lon (n_read))
+      allocate (ob_qc (n_read))
+      allocate (ob_rcp (n_read))
+      allocate (ob_sss (n_read))
+      allocate (ob_sst (n_read))
+      allocate (ob_typ (n_read))
+
+      read (10) ob_age(1:n_read)
+      read (10) ob_err(1:n_read)
+      read (10) ob_flg(1:n_read)
+      read (10) ob_lat(1:n_read)
+      read (10) ob_lon(1:n_read)
+      read (10) ob_qc(1:n_read)
+      read (10) ob_typ(1:n_read)
+      read (10) ob_sss(1:n_read)
+      read (10) ob_sst(1:n_read)
+      read (10) ob_dtg(1:n_read)
+
+      if (vrsn .eq. 2) then
+         read (10) ob_rcp(1:n_read)
+      else
+         do i = 1, n_read
+         ob_rcp(i) = ob_dtg(i)
+         enddo
+      endif
+
+      open(21,file='window.txt',status='old')
+      read(21,'(a12)') winstart
+      read(21,'(a12)') winend
+      close(21)
+
+      open(20,file='sss.txt',status='new')
+
+      do i=1, n_read
+
+!     HAT10
+      if(ob_lat(i).ge.1.0.and.ob_lat(i).le.50.0.and.
+     6     ob_lon(i).ge.-100.0.and.ob_lon(i).le.-7.0) then
+
+!     time window
+      if(ob_dtg(i).ge.winstart.and.ob_dtg(i).le.winend) then
+
+      if(ob_dtg(i)(11:12).gt."59") ob_dtg(i)(11:12)="59"
+
+!     Missing ob_qc
+      if(ob_qc(i).gt.99.0) ob_qc(i)=99.9
+      if(ob_err(i).gt.9.9) ob_err(i)=9.9
+
+      write(20,25) ob_age(i),ob_dtg(i),ob_err(i),ob_lat(i),
+     6             ob_lon(i),ob_qc(i),ob_sss(i)
+
+      endif ! time window 
+
+      endif ! HAT10
+
+      enddo
+
+25    format(f8.1,1x,a12,1x,f4.2,1x,f6.3,1x,f8.3,1x,f6.3,1x,f6.3)
+      close(20)
+
+      endif
+
+      stop
+      end
+
+

--- a/obsproc/rtofs/read_sst.F90
+++ b/obsproc/rtofs/read_sst.F90
@@ -1,0 +1,84 @@
+        program read_sst
+
+        character, allocatable:: ob_dtg(:) *12
+        REAL, ALLOCATABLE:: ob_age(:),ob_bias(:),ob_err(:)
+        REAL, ALLOCATABLE:: ob_flg(:),ob_lat(:),ob_lon(:),ob_qc(:)
+        REAL, ALLOCATABLE:: ob_sst(:)
+        INTEGER, ALLOCATABLE:: ob_typ(:),ob_wm(:)
+
+        character winstart *12, winend *12
+        integer n_read
+        integer vrsn
+        integer i
+
+        open(10,file='sst.bin',form='unformatted')
+
+        n_sst = 0
+        write(*,*) 'reading SST'
+
+        read (10) n_read, n_chn, vrsn
+        
+        if (n_read .gt. 0) then
+
+        allocate (ob_age(n_read))
+        allocate (ob_bias(n_read))
+        allocate (ob_dtg(n_read))
+        allocate (ob_err(n_read))
+        allocate (ob_flg(n_read))
+        allocate (ob_lat(n_read))
+        allocate (ob_lon(n_read))
+        allocate (ob_qc(n_read))
+        allocate (ob_sst(n_read))
+        allocate (ob_typ(n_read))
+        allocate (ob_wm(n_read))
+
+        read (10) ob_age(1:n_read)
+        read (10) ob_bias(1:n_read)
+        read (10) ob_dtg(1:n_read)
+        read (10) ob_err(1:n_read)
+        read (10) ob_flg(1:n_read)
+        read (10) ob_lat(1:n_read)
+        read (10) ob_lon(1:n_read)
+        read (10) ob_qc(1:n_read)
+        read (10) ob_sst(1:n_read)
+        read (10) ob_typ(1:n_read)
+        read (10) ob_wm(1:n_read)
+
+        open(21,file='window.txt',status='old')
+        read(21,'(a12)') winstart
+        read(21,'(a12)') winend
+        close(21)
+
+        open(20,file='sst.txt',status='unknown')
+
+        do i=1, n_read
+
+!       HAT10
+        if(ob_lat(i).ge.1.0.and.ob_lat(i).le.50.0.and.
+     6     ob_lon(i).ge.-100.0.and.ob_lon(i).le.-7.0) then
+
+!       time window
+        if(ob_dtg(i).ge.winstart.and.ob_dtg(i).le.winend) then
+
+        if(ob_dtg(i)(11:12).gt."59") ob_dtg(i)(11:12)="59"
+
+!       Missing ob_qc
+        if(ob_qc(i).ge.0.0.and.ob_qc(i).lt.10.0) then
+
+        write(20,25) ob_dtg(i),ob_lat(i),ob_lon(i),
+     6               ob_sst(i),ob_err(i),ob_qc(i)
+
+        endif ! End of missing ob_qc
+        endif ! End of time window 
+        endif ! End of HAT10
+
+        enddo
+
+25      format(a12,1x,f6.3,1x,f8.3,3(1x,f6.3))
+        close(20)
+
+        endif
+
+        stop
+        end
+

--- a/obsproc/rtofs/readme
+++ b/obsproc/rtofs/readme
@@ -1,0 +1,2 @@
+convert RTOFS operational obs binary to IODA V2
+

--- a/obsproc/rtofs/readme
+++ b/obsproc/rtofs/readme
@@ -1,2 +1,0 @@
-convert RTOFS operational obs binary to IODA V2
-

--- a/obsproc/rtofs/rtofs_ascii2iodav2.py
+++ b/obsproc/rtofs/rtofs_ascii2iodav2.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse
+import netCDF4 as nc
+import numpy as np
+from datetime import datetime, timedelta
+import os
+from pathlib import Path
+
+IODA_CONV_PATH = Path(__file__).parent/"../lib/pyiodaconv"
+if not IODA_CONV_PATH.is_dir():
+    IODA_CONV_PATH = Path(__file__).parent/'..'/'lib-python'
+sys.path.append(str(IODA_CONV_PATH.resolve()))
+
+import ioda_conv_engines as iconv
+from collections import defaultdict, OrderedDict
+from orddicts import DefaultOrderedDict
+
+locationKeyList = [
+    ("latitude", "float"),
+    ("longitude", "float"),
+    ("datetime", "string"),
+]
+
+obsvars = { '': '', }
+
+AttrData = { 'converter': os.path.basename(__file__),
+    'nvars': np.int32(len(obsvars)),
+}
+
+DimDict = { }
+
+VarDims = {
+	" ": ['nlocs']
+}
+
+class marine(object):
+    def __init__(self, filename, varname):
+        self.filename = filename
+        self.varname = varname
+        self.varDict = defaultdict(lambda: defaultdict(dict))
+        self.metaDict = defaultdict(lambda: defaultdict(dict))
+        self.outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
+        self.var_mdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
+        #self.VarAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
+        self.units = {}
+        self._read()
+
+    # Open input file and read relevant info
+    def _read(self):
+        print("input ",self.filename)
+        print("variable ",self.varname)
+
+        obs_line = open(self.filename, "r")
+        lines = len(obs_line.readlines())
+        #print(lines)
+
+        age=np.ndarray(shape=(lines), dtype=np.float32, order='F')
+        lat=np.ndarray(shape=(lines), dtype=np.float32, order='F')
+        lon=np.ndarray(shape=(lines), dtype=np.float32, order='F')
+        err=np.ndarray(shape=(lines), dtype=np.float32, order='F')
+        var=np.ndarray(shape=(lines), dtype=np.float32, order='F')
+        qc=np.ndarray(shape=(lines), dtype=np.int32, order='F')
+        dates = []
+
+        obs_txt = open(self.filename, "r")
+        i=0
+        for line in obs_txt:
+            a = float(line.split()[0])
+            b = str(line.split()[1])
+            c = float(line.split()[2])
+            d = float(line.split()[3])
+            e = float(line.split()[4])
+            f = float(line.split()[5])
+            g = float(line.split()[6])
+
+            age[i]=a
+            
+            ss = str(datetime.strptime(b, '%Y%m%d%H%M'))
+            s2 = ss[0:10]+"T"+ss[11:19]+"Z"
+            dates.append(s2)
+
+            err[i]=c
+            lat[i]=d
+            lon[i]=e
+            qc[i]=f
+            var[i]=g
+            #print(i)
+            i=i+1
+        obs_txt.close()
+
+        self.outdata[('datetime', 'MetaData')]=np.empty(len(dates), dtype=object)
+        self.outdata[('datetime', 'MetaData')][:] = dates
+
+        self.outdata[('latitude', 'MetaData')]=lat
+        self.outdata[('longitude', 'MetaData')]=lon
+        self.outdata[(self.varname, 'ObsError')]=err
+        self.outdata[(self.varname, 'ObsValue')]=var
+        self.outdata[(self.varname, 'PreQC')]=qc
+
+        #self.outdata[('sea_surface_temperature', 'ObsError')]=err
+        #self.outdata[('sea_surface_temperature', 'ObsValue')]=var
+        #self.outdata[('sea_surface_temperature', 'PreQC')]=qc
+
+        # get global attributes
+        DimDict['nlocs'] = len(var)
+        AttrData['nlocs'] = np.int32(DimDict['nlocs'])
+
+def main():
+
+    # get command line arguments
+    parser = argparse.ArgumentParser(
+        description=(
+            'read RTOFS obs ascii file'
+            'write IODA V2 netCDF file')
+    )
+
+    required = parser.add_argument_group(title='required arguments')
+    required.add_argument(
+        '-i', '--input',
+        help="RTOFS obs ascii input file",
+        type=str, required=True)
+    required.add_argument(
+        '-v', '--varname',
+        help="IODA V2 variable name, e.g., sea_surface_temperature",
+        type=str, required=True)
+    required.add_argument(
+        '-o', '--output',
+        help="IODA V2 output file",
+        type=str, required=True)
+    args = parser.parse_args()
+
+    # Read in the marine data
+    obs = marine(args.input,args.varname)
+
+    # setup the IODA writer
+    writer = iconv.IodaWriter(args.output, locationKeyList, DimDict)
+
+    # write everything out
+    writer.BuildIoda(obs.outdata, VarDims, obs.var_mdata, AttrData, obs.units)
+
+if __name__ == '__main__':
+    main()
+

--- a/obsproc/rtofs/rtofs_ascii2iodav2.py
+++ b/obsproc/rtofs/rtofs_ascii2iodav2.py
@@ -56,36 +56,39 @@ class marine(object):
         lines = len(obs_line.readlines())
         #print(lines)
 
-        age=np.ndarray(shape=(lines), dtype=np.float32, order='F')
         lat=np.ndarray(shape=(lines), dtype=np.float32, order='F')
         lon=np.ndarray(shape=(lines), dtype=np.float32, order='F')
+        val=np.ndarray(shape=(lines), dtype=np.float32, order='F')
         err=np.ndarray(shape=(lines), dtype=np.float32, order='F')
-        var=np.ndarray(shape=(lines), dtype=np.float32, order='F')
-        qc=np.ndarray(shape=(lines), dtype=np.int32, order='F')
+        qc =np.ndarray(shape=(lines), dtype=np.int32, order='F')
+         
+        if ( self.varname == 'sea_water_temperature' ):
+           sws_val=np.ndarray(shape=(lines), dtype=np.float32, order='F')
+           sws_err=np.ndarray(shape=(lines), dtype=np.float32, order='F')
+           sws_qc =np.ndarray(shape=(lines), dtype=np.int32, order='F')
+           depth  =np.ndarray(shape=(lines), dtype=np.float32, order='F')
+       
         dates = []
 
         obs_txt = open(self.filename, "r")
         i=0
         for line in obs_txt:
-            a = float(line.split()[0])
-            b = str(line.split()[1])
-            c = float(line.split()[2])
-            d = float(line.split()[3])
-            e = float(line.split()[4])
-            f = float(line.split()[5])
-            g = float(line.split()[6])
-
-            age[i]=a
-            
+            b = str(line.split()[0])
             ss = str(datetime.strptime(b, '%Y%m%d%H%M'))
             s2 = ss[0:10]+"T"+ss[11:19]+"Z"
             dates.append(s2)
 
-            err[i]=c
-            lat[i]=d
-            lon[i]=e
-            qc[i]=f
-            var[i]=g
+            lat[i] = float(line.split()[1])
+            lon[i] = float(line.split()[2])
+            val[i] = float(line.split()[3])
+            err[i] = float(line.split()[4])
+            qc[i]  = float(line.split()[5])
+
+            if ( self.varname == 'sea_water_temperature' ):
+               sws_val[i] = float(line.split()[6])
+               sws_err[i] = float(line.split()[7])
+               sws_qc[i]  = float(line.split()[8])
+               depth[i]   = float(line.split()[9])
             #print(i)
             i=i+1
         obs_txt.close()
@@ -93,18 +96,21 @@ class marine(object):
         self.outdata[('datetime', 'MetaData')]=np.empty(len(dates), dtype=object)
         self.outdata[('datetime', 'MetaData')][:] = dates
 
-        self.outdata[('latitude', 'MetaData')]=lat
-        self.outdata[('longitude', 'MetaData')]=lon
+        self.outdata[('latitude', 'MetaData')]  =lat
+        self.outdata[('longitude', 'MetaData')] =lon
         self.outdata[(self.varname, 'ObsError')]=err
-        self.outdata[(self.varname, 'ObsValue')]=var
-        self.outdata[(self.varname, 'PreQC')]=qc
+        self.outdata[(self.varname, 'ObsValue')]=val
+        self.outdata[(self.varname, 'PreQC')]   =qc
 
-        #self.outdata[('sea_surface_temperature', 'ObsError')]=err
-        #self.outdata[('sea_surface_temperature', 'ObsValue')]=var
-        #self.outdata[('sea_surface_temperature', 'PreQC')]=qc
+        if ( self.varname == 'sea_water_temperature' ):
+           print('sea_water_salinity')
+           self.outdata[('sea_water_salinity', 'ObsError')]=sws_err
+           self.outdata[('sea_water_salinity', 'ObsValue')]=sws_val
+           self.outdata[('sea_water_salinity', 'PreQC')]   =sws_qc
+           self.outdata[('depth', 'MetaData')]=depth
 
         # get global attributes
-        DimDict['nlocs'] = len(var)
+        DimDict['nlocs'] = len(val)
         AttrData['nlocs'] = np.int32(DimDict['nlocs'])
 
 def main():

--- a/obsproc/rtofs/rtofs_ascii2iodav2.sh
+++ b/obsproc/rtofs/rtofs_ascii2iodav2.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 
-YMD=20201026
-plat=metop
-./rtofs_ascii2iodav2.py -i sst.txt -v sea_surface_temperature -o ./sst_${plat}_${YMD}.nc
-
 #YMD=20201018
 #plat=ssh
+#./read_ssh.exe
 #./rtofs_ascii2iodav2.py -i ssh.txt -v absolute_dynamic_topography -o ./adt_${plat}_${YMD}.nc
 
 #YMD=20210131
 #plat=salinity
+#./read_sss.exe
 #./rtofs_ascii2iodav2.py -i sss.txt -v sea_surface_salinity -o ./sss_${plat}_${YMD}.nc
+
+YMD=20201026
+plat=metop
+#./read_sst.exe
+./rtofs_ascii2iodav2.py -i sst.txt -v sea_surface_temperature -o ./sst_${plat}_${YMD}.nc
 
 YMD=20201024
 plat=profile
+#./read_profile.exe
 ./rtofs_ascii2iodav2.py -i profile.txt -v sea_water_temperature -o ./insitu_${plat}_${YMD}.nc

--- a/obsproc/rtofs/rtofs_ascii2iodav2.sh
+++ b/obsproc/rtofs/rtofs_ascii2iodav2.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#YMD=20201026
+#plat=metop
+#./rtofs_ascii2iodav2.py -i sst.txt -v sea_surface_temperature -o ./sst_${plat}_${YMD}.nc
+
+#YMD=20201018
+#plat=ssh
+#./rtofs_ascii2iodav2.py -i ssh.txt -v absolute_dynamic_topography -o ./adt_${plat}_${YMD}.nc
+
+YMD=20210131
+plat=salinity
+./rtofs_ascii2iodav2.py -i sss.txt -v sea_surface_salinity -o ./sss_${plat}_${YMD}.nc
+

--- a/obsproc/rtofs/rtofs_ascii2iodav2.sh
+++ b/obsproc/rtofs/rtofs_ascii2iodav2.sh
@@ -8,7 +8,10 @@
 #plat=ssh
 #./rtofs_ascii2iodav2.py -i ssh.txt -v absolute_dynamic_topography -o ./adt_${plat}_${YMD}.nc
 
-YMD=20210131
-plat=salinity
-./rtofs_ascii2iodav2.py -i sss.txt -v sea_surface_salinity -o ./sss_${plat}_${YMD}.nc
+#YMD=20210131
+#plat=salinity
+#./rtofs_ascii2iodav2.py -i sss.txt -v sea_surface_salinity -o ./sss_${plat}_${YMD}.nc
 
+YMD=20201024
+plat=profile
+./rtofs_ascii2iodav2.py -i profile.txt -v sea_water_temperature -o ./insitu_${plat}_${YMD}.nc

--- a/obsproc/rtofs/rtofs_ascii2iodav2.sh
+++ b/obsproc/rtofs/rtofs_ascii2iodav2.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-#YMD=20201026
-#plat=metop
-#./rtofs_ascii2iodav2.py -i sst.txt -v sea_surface_temperature -o ./sst_${plat}_${YMD}.nc
+YMD=20201026
+plat=metop
+./rtofs_ascii2iodav2.py -i sst.txt -v sea_surface_temperature -o ./sst_${plat}_${YMD}.nc
 
 #YMD=20201018
 #plat=ssh


### PR DESCRIPTION
## Description
This PR will convert RTOFS operational observation binary data into IODA v2. The shell script, Fortran, and python codes are used.
This PR is linked to [issues #371](https://github.com/NOAA-EMC/godas/issues/371)

### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- closes #371

## Dependencies
IODA V2 library
