### PR TITLE
update yamls and add obs yamls

### DIFF
--- a/soca/obs/icec_amsr2_north.yaml
+++ b/soca/obs/icec_amsr2_north.yaml
@@ -1,15 +1,15 @@
 - obs space:
-    name: icec_nsidc_sh
+    name: icec_amsr2_north
     distribution:
       name: *obs_distribution
     obsdatain:
       engine:
         type: H5File
-        obsfile: $(experiment_dir)/{{current_cycle}}/icec_nsidc_sh.{{window_begin}}.nc4
+        obsfile: $(experiment_dir)/{{current_cycle}}/icec_amsr2_north.{{window_begin}}.nc4
     obsdataout:
       engine:
         type: H5File
-        obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icec_nsidc_sh.{{window_begin}}.nc4
+        obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icec_amsr2_north.{{window_begin}}.nc4
     simulated variables: [sea_ice_area_fraction]
   obs operator:
     name: Identity
@@ -29,8 +29,9 @@
       name: passivate
     where:
     - variable: {name: sea_area_fraction@GeoVaLs}
-    maxvalue: 0.9
+      maxvalue: 0.9
   - filter: Domain Check
     where:
     - variable: { name: sea_surface_temperature@GeoVaLs}
       maxvalue: 0.9
+

--- a/soca/obs/icec_amsr2_south.yaml
+++ b/soca/obs/icec_amsr2_south.yaml
@@ -1,15 +1,15 @@
 - obs space:
-    name: icec_nsidc_sh
+    name: icec_amsr2_south
     distribution:
       name: *obs_distribution
     obsdatain:
       engine:
         type: H5File
-        obsfile: $(experiment_dir)/{{current_cycle}}/icec_nsidc_sh.{{window_begin}}.nc4
+        obsfile: $(experiment_dir)/{{current_cycle}}/icec_amsr2_south.{{window_begin}}.nc4
     obsdataout:
       engine:
         type: H5File
-        obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icec_nsidc_sh.{{window_begin}}.nc4
+        obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icec_amsr2_south.{{window_begin}}.nc4
     simulated variables: [sea_ice_area_fraction]
   obs operator:
     name: Identity
@@ -29,7 +29,7 @@
       name: passivate
     where:
     - variable: {name: sea_area_fraction@GeoVaLs}
-    maxvalue: 0.9
+      maxvalue: 0.9
   - filter: Domain Check
     where:
     - variable: { name: sea_surface_temperature@GeoVaLs}

--- a/soca/obs/icec_nsidc_nh.yaml
+++ b/soca/obs/icec_nsidc_nh.yaml
@@ -23,11 +23,13 @@
       lengthscale: 200e3
   obs filters:
   - *obs_land_mask
-  - filter: Bounds Check
-    minvalue: 0.0
-    maxvalue: 1.0
-  - filter: Background Check
-    threshold: 5.0
+  # Passivate obs where ocean fraction is > 90%
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      maxvalue: 0.9
   - filter: Domain Check
     where:
     - variable: { name: sea_surface_temperature@GeoVaLs}

--- a/soca/obs/icefb_c2_esa.yaml
+++ b/soca/obs/icefb_c2_esa.yaml
@@ -13,14 +13,15 @@
     name: SeaIceThickness
   obs error:
     covariance model: diagonal
-  #_letkf: &letkf
-  #  # note, this is only used for LETKF. If running with LETKF, the workflow
-  #  # will append "<< : *letkf" to the end of this file
-  #  obs localizations:
-  #  - localization method: Horizontal Gaspari-Cohn
-  #    lengthscale: 500e3
   obs filters:
   - *obs_land_mask
+  # Remove obs in the Southerm Hemisphere
+  - filter: BlackList
+    where:
+    - variable:
+        name: latitude@MetaData
+      minvalue: -5
+      maxvalue: -90
   - filter: Bounds Check
     minvalue: -0.1
     maxvalue: 1.0
@@ -38,3 +39,4 @@
         name: sea_ice_category_thickness@GeoVaLs
       minvalue: 0.5
       maxvalue: 5.0
+

--- a/soca/obs/icefb_c2_esa.yaml
+++ b/soca/obs/icefb_c2_esa.yaml
@@ -1,0 +1,40 @@
+- obs space:
+    name: icefb_c2_esa
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: $(experiment_dir)/{{current_cycle}}/icefb_c2_esa.{{window_begin}}.nc4
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icefb_c2_esa.{{window_begin}}.nc4
+    simulated variables:  [sea_ice_freeboard]
+  obs operator:
+    name: SeaIceThickness
+  obs error:
+    covariance model: diagonal
+  #_letkf: &letkf
+  #  # note, this is only used for LETKF. If running with LETKF, the workflow
+  #  # will append "<< : *letkf" to the end of this file
+  #  obs localizations:
+  #  - localization method: Horizontal Gaspari-Cohn
+  #    lengthscale: 500e3
+  obs filters:
+  - *obs_land_mask
+  - filter: Bounds Check
+    minvalue: -0.1
+    maxvalue: 1.0
+  - filter: Domain Check
+    where:
+    - variable: { name: sea_surface_temperature@GeoVaLs}
+      maxvalue: -0.5
+  - filter: Background Check
+    threshold: 3.0
+  - filter: Domain Check
+    filter variables:
+    - name: sea_ice_freeboard
+    where:
+    - variable:
+        name: sea_ice_category_thickness@GeoVaLs
+      minvalue: 0.5
+      maxvalue: 5.0

--- a/soca/obs/icefb_c2_esa.yaml
+++ b/soca/obs/icefb_c2_esa.yaml
@@ -20,8 +20,8 @@
     where:
     - variable:
         name: latitude@MetaData
-      minvalue: -5
-      maxvalue: -90
+      minvalue: -90
+      maxvalue: -5
   - filter: Bounds Check
     minvalue: -0.1
     maxvalue: 1.0

--- a/soca/obs/icethk_coperl4.yaml
+++ b/soca/obs/icethk_coperl4.yaml
@@ -1,0 +1,26 @@
+- obs space:
+    name: icethk_coperl4
+    distribution:
+      name: *obs_distribution
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: $(experiment_dir)/{{current_cycle}}/icethk_coperl4.{{window_begin}}.nc4
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).icethk_coperl4.{{window_begin}}.nc4
+    simulated variables: [sea_ice_category_thickness]
+  obs operator:
+    name: Identity
+  obs error:
+    covariance model: diagonal
+  obs filters:
+  - *obs_land_mask
+  # Passivate obs where ocean fraction is > 90%
+  - filter: Domain Check
+    action:
+      name: passivate
+    where:
+    - variable: {name: sea_area_fraction@GeoVaLs}
+      maxvalue: 0.9

--- a/soca/soca_3dvar.yaml
+++ b/soca/soca_3dvar.yaml
@@ -16,6 +16,7 @@ _corr:
 # placeholders used by the obs yaml files that will be placed
 #  where _OBSERVATIONS_ token is
 _: &obs_distribution RoundRobin
+_: &obs_distribution_opt {}
 _: &obs_land_mask
   filter: Domain Check
   where:
@@ -32,7 +33,7 @@ variational:
   - geometry:
       mom6_input_nml: mom_input.nml
       fields metadata: fields_metadata.yaml
-    ninner: 100
+    ninner: 150
     gradient norm reduction: 1e-3
     test: on
     diagnostics:
@@ -71,12 +72,6 @@ cost function:
     state variables: [__DA_VARIABLES__, mld, layer_depth]
 
   background error:
-#    covariance model: SABER
-#    saber blocks:
-#    - saber block name: ID
-#      input variables: *soca_vars
-#      output variables: *soca_vars
-
     covariance model: SocaError
     analysis variables: [__DA_VARIABLES__]
     date: *bkg_date
@@ -91,10 +86,6 @@ cost function:
       input variables: *soca_vars
       output variables: *soca_vars
       linear variable changes:
-
-#      - linear variable change name: HorizFiltSOCA
-#        niter: 6
-#        filter variables: *soca_vars
 
       - linear variable change name: VertConvSOCA
         Lz_min: 0.0
@@ -117,14 +108,14 @@ cost function:
         ssh_min: 0.0   # value at EQ
         ssh_max: 0.0   # value in Extratropics
         ssh_phi_ex: 20 # lat of transition from extratropics
-        chl_min: 0.003
-        chl_max: 10.0
-        biop_min: 0.0
-        biop_max: 1.0e-6
         cicen_min: 0.05
         cicen_max: 0.05
         hicen_min: 0.1
         hicen_max: 0.1
+
+#      - linear variable change name: HorizFiltSOCA
+#        niter: 2
+#        filter variables: *soca_vars
 
       - linear variable change name: BalanceSOCA
         dsdtmax: 0.1

--- a/soca/soca_3dvar_3dbump.yaml
+++ b/soca/soca_3dvar_3dbump.yaml
@@ -16,6 +16,7 @@ _corr:
 # placeholders used by the obs yaml files that will be placed
 #  where _OBSERVATIONS_ token is
 _: &obs_distribution RoundRobin
+_: &obs_distribution_opt {}
 _: &obs_land_mask
   filter: Domain Check
   where:
@@ -73,14 +74,11 @@ cost function:
   background error:
 
     covariance model: SABER
-    saber blocks:
-    - saber block name: BUMP_NICAS
-      saber central block: true
-      iterative inverse: true
-      input variables: *soca_vars
-      output variables: *soca_vars
+    saber central block:
+      saber block name: BUMP_NICAS
+      active variables: *soca_vars
       bump:
-        verbosity: main
+        #verbosity: main
         datadir: ./bump
         strategy: specific_univariate
         load_nicas_local: true

--- a/soca/soca_3dvar_3dbump.yaml
+++ b/soca/soca_3dvar_3dbump.yaml
@@ -78,7 +78,6 @@ cost function:
       saber block name: BUMP_NICAS
       active variables: *soca_vars
       bump:
-        #verbosity: main
         datadir: ./bump
         strategy: specific_univariate
         load_nicas_local: true

--- a/soca/soca_setcorscales.yaml
+++ b/soca/soca_setcorscales.yaml
@@ -7,31 +7,31 @@ date: 2019-08-31T12:00:00Z
 corr variables: [socn, tocn, ssh, hocn, cicen, hicen, hsnon]
 
 scales:
-  vert layers: 5 # in units of layer
+  vert layers: 10 # in units of layer
   socn:
-    rossby mult: 0.28
-    min grid mult: 0.28
+    rossby mult: 1.0
+    min grid mult: 2.0
   tocn:
-    rossby mult: 0.28
-    min grid mult: 0.28
+    rossby mult: 1.0
+    min grid mult: 2.0
   hocn:
     rossby mult: 100.0
     min grid mult: 100.0
   ssh:
-    rossby mult: 0.28
-    min grid mult: 0.28
+    rossby mult: 1.0
+    min grid mult: 2.0
   cicen:
     rossby mult: 0.0
-    min grid mult: 1.0
-    min: 50.0
+    min grid mult: 2.0
+    min: 50000.0
   hicen:
     rossby mult: 0.0
-    min grid mult: 1.0
-    min: 150.0
+    min grid mult: 2.0
+    min: 150000.0
   hsnon:
     rossby mult: 0.0
-    min grid mult: 1.0
-    min: 1000.0
+    min grid mult: 2.0
+    min: 150000.0
 
 rh output:
   datadir: ./


### PR DESCRIPTION
## Description
This PR adds new obs yamls for:
1. icec: amsr2-, L NSIDC
2. icefb: c2_esa
3. icethk: coperl4

Fixes bug in yaml for units:
soca_setcorrscales (ice decorrelation length scales)

Updates yamls for 3dvar:
soca_3dvar.yaml
soca_3dvar_bump3d.yaml

### Issue(s) addressed

- fixes #431
- fixes #436

