### PR TITLE
Add LETKF obs_stats diagnostics

### DIFF
--- a/applications/cycle_diagnostics/letkf_obsstats.py
+++ b/applications/cycle_diagnostics/letkf_obsstats.py
@@ -54,11 +54,11 @@ for obsfile in diags_list:
             'csv_output': os.path.join(comout, 'letkf', 'diags', f"{obs_space}.stats.csv")}
     obs_spaces.append(create_obs_space(data))
 
-    # create the yaml
-    data = {'obs_spaces': obs_spaces, 'nens': nens}
-    conf = parse_j2yaml(path=obsstats_j2yaml, data=data)
-    stats_yaml = 'diag_stats.yaml'
-    conf.save(stats_yaml)
+# create the yaml
+data = {'obs_spaces': obs_spaces, 'nens': nens}
+conf = parse_j2yaml(path=obsstats_j2yaml, data=data)
+stats_yaml = 'diag_stats.yaml'
+conf.save(stats_yaml)
 
 # Path to your executable
 exe_path = HOMEgfs + '/sorc/gdas.cd/build/bin/gdassoca_obsstats.x'

--- a/applications/cycle_diagnostics/letkf_obsstats.py
+++ b/applications/cycle_diagnostics/letkf_obsstats.py
@@ -30,6 +30,7 @@ def create_obs_space(data):
                }
     return os_dict
 
+
 # get the experiment id
 pslot = os.getenv("PSLOT")
 

--- a/applications/cycle_diagnostics/letkf_obsstats.py
+++ b/applications/cycle_diagnostics/letkf_obsstats.py
@@ -1,19 +1,19 @@
 import os
 import glob
-import yaml
 import subprocess
 import re
 import netCDF4
 from wxflow import parse_j2yaml
 
 # obs space statistics
-print(f"---------------- Compute basic stats")
+print("---------------- Compute basic stats")
 comout = os.getenv('COM_OCEAN_ANALYSIS')
 HOMEgdasmv = os.getenv('HOMEgdasmv')
 HOMEgfs = os.getenv('HOMEgfs')
 nens = os.getenv('NENS')
 diags_list = glob.glob(os.path.join(os.path.join(comout, 'letkf', 'diags', '*.nc4')))
 obsstats_j2yaml = os.path.join(HOMEgdasmv, 'configs', 'obs_stats.yaml.j2')
+
 
 # function to create a minimalist ioda obs sapce
 def create_obs_space(data):
@@ -27,11 +27,12 @@ def create_obs_space(data):
                "variable": data["variable"],
                "experiment identifier": data["pslot"],
                "csv output": data["csv_output"]
-              }
+               }
     return os_dict
 
 # get the experiment id
 pslot = os.getenv("PSLOT")
+
 
 # iterate through the obs spaces and generate the yaml for gdassoca_obsstats.x
 obs_spaces = []

--- a/applications/cycle_diagnostics/letkf_obsstats.py
+++ b/applications/cycle_diagnostics/letkf_obsstats.py
@@ -1,0 +1,65 @@
+import os
+import glob
+import yaml
+import subprocess
+import re
+import netCDF4
+from wxflow import parse_j2yaml
+
+# obs space statistics
+print(f"---------------- Compute basic stats")
+comout = os.getenv('COM_OCEAN_ANALYSIS')
+HOMEgdasmv = os.getenv('HOMEgdasmv')
+HOMEgfs = os.getenv('HOMEgfs')
+nens = os.getenv('NENS')
+diags_list = glob.glob(os.path.join(os.path.join(comout, 'letkf', 'diags', '*.nc4')))
+obsstats_j2yaml = os.path.join(HOMEgdasmv, 'configs', 'obs_stats.yaml.j2')
+
+# function to create a minimalist ioda obs sapce
+def create_obs_space(data):
+    os_dict = {"obs space": {
+               "name": data["obs_space"],
+               "obsdatain": {
+                   "engine": {"type": "H5File", "obsfile": data["obsfile"]}
+               },
+               "simulated variables": [data["variable"]]
+               },
+               "variable": data["variable"],
+               "experiment identifier": data["pslot"],
+               "csv output": data["csv_output"]
+              }
+    return os_dict
+
+# get the experiment id
+pslot = os.getenv("PSLOT")
+
+# iterate through the obs spaces and generate the yaml for gdassoca_obsstats.x
+obs_spaces = []
+for obsfile in diags_list:
+    # define an obs space name
+    obs_space = re.sub(r'\.\d{10}\.nc4$', '', os.path.basename(obsfile))
+
+    # get the variable name, assume 1 variable per file
+    nc = netCDF4.Dataset(obsfile, 'r')
+    variable = next(iter(nc.groups["ombg"].variables))
+    nc.close()
+
+    # filling values for the templated yaml
+    data = {'obs_space': os.path.basename(obsfile),
+            'obsfile': obsfile,
+            'pslot': pslot,
+            'variable': variable,
+            'csv_output': os.path.join(comout, 'letkf', 'diags', f"{obs_space}.stats.csv")}
+    obs_spaces.append(create_obs_space(data))
+
+    # create the yaml
+    data = {'obs_spaces': obs_spaces, 'nens': nens}
+    conf = parse_j2yaml(path=obsstats_j2yaml, data=data)
+    stats_yaml = 'diag_stats.yaml'
+    conf.save(stats_yaml)
+
+# Path to your executable
+exe_path = HOMEgfs + '/sorc/gdas.cd/build/bin/gdassoca_obsstats.x'
+
+# Run the executable
+result = subprocess.run([exe_path, stats_yaml], capture_output=True, text=True)

--- a/applications/obsstats_ts/gdassoca_obsstats.py
+++ b/applications/obsstats_ts/gdassoca_obsstats.py
@@ -71,12 +71,14 @@ class ObsStats:
             ]
 
             # Plot RMSE, obs error, obs error + spread
-            axs[0].plot(exp_data['date'], exp_data['RMSE'], marker='o', linestyle='-', color=colors[exp_counter], label='RMSE '+exp)
+            axs[0].plot(exp_data['date'], exp_data['RMSE'], marker='o', linestyle='-',
+                        color=colors[exp_counter], label='RMSE ' + exp)
             if ('EnsStd' in exp_data) and ('ObsErr' in exp_data):
-                axs[0].plot(exp_data['date'], exp_data['EnsStd']+exp_data['ObsErr'], marker='s', linestyle='-',
-                            color=colors[exp_counter], label='EnsStd+ObsErr '+exp)
+                axs[0].plot(exp_data['date'], exp_data['EnsStd'] + exp_data['ObsErr'], marker='s', linestyle='-',
+                            color=colors[exp_counter], label='EnsStd+ObsErr ' + exp)
             if ('EnsStd' in exp_data):
-                axs[0].plot(exp_data['date'], exp_data['EnsStd'], marker='x', linestyle='-', color=colors[exp_counter], label='EnsStd '+exp)
+                axs[0].plot(exp_data['date'], exp_data['EnsStd'], marker='x', linestyle='-',
+                            color=colors[exp_counter], label='EnsStd ' + exp)
             axs[0].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H'))
             axs[0].xaxis.set_major_locator(mdates.DayLocator())
             axs[0].tick_params(labelbottom=False)

--- a/applications/obsstats_ts/gdassoca_obsstats.py
+++ b/applications/obsstats_ts/gdassoca_obsstats.py
@@ -29,7 +29,7 @@ colors = [
 
 def get_inst(csv_file_name):
     """Extract the instrument name from the csv file name. gdas.t00z.ocn.sst_ahi_h08_l3c.stats.csv -> sst_ahi_h08_l3c"""
-    return csv_file_name.split('.')[-3]
+    return csv_file_name.split('.')[-3].split('/')[-1]
 
 
 class ObsStats:
@@ -70,8 +70,13 @@ class ObsStats:
                 & (self.data['Exp'] == exp)
             ]
 
-            # Plot RMSE
-            axs[0].plot(exp_data['date'], exp_data['RMSE'], marker='o', linestyle='-', color=colors[exp_counter], label=exp)
+            # Plot RMSE, obs error, obs error + spread
+            axs[0].plot(exp_data['date'], exp_data['RMSE'], marker='o', linestyle='-', color=colors[exp_counter], label='RMSE '+exp)
+            if ('EnsStd' in exp_data) and ('ObsErr' in exp_data):
+                axs[0].plot(exp_data['date'], exp_data['EnsStd']+exp_data['ObsErr'], marker='s', linestyle='-',
+                            color=colors[exp_counter], label='EnsStd+ObsErr '+exp)
+            if ('EnsStd' in exp_data):
+                axs[0].plot(exp_data['date'], exp_data['EnsStd'], marker='x', linestyle='-', color=colors[exp_counter], label='EnsStd '+exp)
             axs[0].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H'))
             axs[0].xaxis.set_major_locator(mdates.DayLocator())
             axs[0].tick_params(labelbottom=False)
@@ -109,7 +114,7 @@ if __name__ == "__main__":
     epilog = [
         "Usage examples:",
         "./gdassoca_obsstats.py --exps cp1/COMROOT/cp1 cp2/COMROOT/cp2",
-        "--inst sst_abi_g16_l3c --dirout cp1vscp2"
+        "--inst sst_abi_g16_l3c --dirout cp1vscp2 [--letkf]"
     ]
     parser = argparse.ArgumentParser(description="Observation space RMSE's and BIAS's",
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -122,6 +127,7 @@ if __name__ == "__main__":
         help="The name of the instrument/platform (ex: sst_abi_g16_l3c) or a wild card (eg sst*)"
     )
     parser.add_argument("--dirout", required=True, help="Output directory")
+    parser.add_argument("--letkf", action="store_true", help="Generate stats for LETKF diag files")
     args = parser.parse_args()
 
     insts = []
@@ -131,6 +137,8 @@ if __name__ == "__main__":
     # Get all instruments/obs spaces
     for exp in args.exps:
         wc = exp + f'/*.*/??/analysis/ocean/*{inst}*.stats.csv'
+        if (args.letkf):
+            wc = exp + f'/*.*/??/analysis/ocean/letkf/diags/*{inst}*.stats.csv'
         flist = glob.glob(wc)
         for fname in flist:
             insts.append(get_inst(fname))
@@ -144,6 +152,8 @@ if __name__ == "__main__":
         flist = []
         for exp in args.exps:
             wc = exp + f'/*.*/??/analysis/ocean/*{inst}*.stats.csv'
+            if (args.letkf):
+                wc = exp + f'/*.*/??/analysis/ocean/letkf/diags/*{inst}*.stats.csv'
             flist.append(glob.glob(wc))
 
         flist = sum(flist, [])

--- a/configs/obs_stats.yaml.j2
+++ b/configs/obs_stats.yaml.j2
@@ -1,0 +1,7 @@
+time window:
+  begin: '1900-01-01T00:00:00Z'
+  end: '2035-01-01T00:00:00Z'
+  bound to include: begin
+nens: {{ nens }}
+obs spaces:
+  {{ obs_spaces }}

--- a/configs/vrfy_config.yaml
+++ b/configs/vrfy_config.yaml
@@ -2,8 +2,10 @@ pslot: "mlb.02"
 start_pdy: '20210701'
 end_pdy: '20210701'
 cycs: ["06"]
+nens: 30
 run: "gdas"
 homegdasmarineviz: "/work2/noaa/da/gvernier/sandboxes/gdas-marine-viz/"
+# homegfs: "path/to/global-workflow"   # used for computing LETKF obsstats
 base_exp_path: "/work2/noaa/da/gvernier/runs/mlb/{{ pslot }}/COMROOT/{{ pslot }}"
 vrfyout: "/work2/noaa/da/gvernier/sandboxes/gdas-marine-viz/test/{{ pslot }}"
 plot_ensemble_b: "OFF"
@@ -14,6 +16,7 @@ plot_analysis: "OFF"
 plot_letkf_ensemble: "OFF"
 eva_plots: "ON"
 eva_letkf_plots: "OFF"
+compute_letkf_obsstats: "OFF"
 qos: "batch"
 hpc: "hercules"
 eva_module: "EVA/orion"

--- a/templates/vrfy_jobcard.sh.j2
+++ b/templates/vrfy_jobcard.sh.j2
@@ -15,6 +15,7 @@
 
 # Define HOMEgdas
 export HOMEgdasmv="{{ homegdasmarineviz }}"
+export HOMEgfs="{{ homegfs }}"
 
 # Define HPC Machines
 export HPCname="{{ hpc }}"
@@ -35,6 +36,8 @@ export PLOT_INCREMENT={{ plot_increment | default("ON") }}
 export PLOT_ANALYSIS={{ plot_analysis | default("OFF") }}
 export EVA_PLOTS={{ eva_plots | default("OFF") }}
 export EVA_LETKF_PLOTS={{ eva_letkf_plots | default("OFF") }}
+export COMPUTE_LETKF_OBSSTATS={{ compute_letkf_obsstats | default("OFF") }}
+export NENS={{ nens | default(0) }}
 
 # Define and export the environment variables
 export cyc="{{ cyc }}"
@@ -58,3 +61,13 @@ export COM_OCEAN_HISTORY_PREV="${BASE_EXP_PATH}/gdas.${PREV_PDY}/${PREV_CYC_HOUR
 
 # Execute Marine Verify Analysis
 python3 ${HOMEgdasmv}/applications/cycle_diagnostics/vrfy_script.py
+
+{% if compute_letkf_obsstats == "ON" %}
+  module purge
+  module use ${HOMEgdasmv}/modulefiles
+  module load {{ gdas_module | default("GDAS/hera.intel") }}
+  wxflowPATH=${HOMEgfs}/ush/python
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
+  export PYTHONPATH
+  python3 ${HOMEgdasmv}/applications/cycle_diagnostics/letkf_obsstats.py
+{% endif %}


### PR DESCRIPTION
## Description

This PR:
- adds an optional run to generate csv stats from letkf diags during run_vrfy
- adds options to plot obs error and ens spread in the obs spalce to obsstats
- adds an option to plot letkf obsstats to obsstats.

I don't currently have a long enough run for an interesting plot unfortunately, but here's an example of Var vs LETKF for one instrument, one date:
 Var that didn't use https://github.com/NOAA-EMC/GDASApp/pull/1592 and so didn't have spread and obserror in csv:
![sst_avhrr_ma_l3u_ombg_qc_Global](https://github.com/user-attachments/assets/b9d49bfd-63d3-4367-bf73-fe3ad41e04aa)

LETKF that used https://github.com/NOAA-EMC/GDASApp/pull/1592 and had spread and obserror in csv:
![sst_avhrr_ma_l3u_ombg_qc_Global](https://github.com/user-attachments/assets/eabc1ccf-1c42-4f9e-ad16-307bbf7b80e0)



### Issue(s) addressed

Closes #492 