### PR TITLE
Improve letkf obsstats diags and some bugfixes

### DIFF
--- a/applications/cycle_diagnostics/letkf_obsstats.py
+++ b/applications/cycle_diagnostics/letkf_obsstats.py
@@ -49,7 +49,7 @@ for obsfile in diags_list:
     # filling values for the templated yaml
     data = {'obs_space': os.path.basename(obsfile),
             'obsfile': obsfile,
-            'pslot': pslot+"_letkf",
+            'pslot': pslot + "_letkf",
             'variable': variable,
             'csv_output': os.path.join(comout, 'letkf', 'diags', f"{obs_space}.stats.csv")}
     obs_spaces.append(create_obs_space(data))

--- a/applications/cycle_diagnostics/letkf_obsstats.py
+++ b/applications/cycle_diagnostics/letkf_obsstats.py
@@ -49,7 +49,7 @@ for obsfile in diags_list:
     # filling values for the templated yaml
     data = {'obs_space': os.path.basename(obsfile),
             'obsfile': obsfile,
-            'pslot': pslot,
+            'pslot': pslot+"_letkf",
             'variable': variable,
             'csv_output': os.path.join(comout, 'letkf', 'diags', f"{obs_space}.stats.csv")}
     obs_spaces.append(create_obs_space(data))

--- a/applications/cycle_diagnostics/vrfy_script.py
+++ b/applications/cycle_diagnostics/vrfy_script.py
@@ -20,28 +20,29 @@ else:
 del matching_paths
 
 com_ice_history = os.getenv('COM_ICE_HISTORY_PREV')
-# resolve the comout path since it may contain wild cards
-matching_paths = glob.glob(com_ice_history)
-if matching_paths:
-    com_ice_history = matching_paths[0]  # Assuming you want the first match
-    print(com_ice_history)
-else:
-    print(com_ice_history)
-    print("No matching paths found")
-    exit(1)
-del matching_paths
-
 com_ocean_history = os.getenv('COM_OCEAN_HISTORY_PREV')
-# resolve the comout path since it may contain wild cards
-matching_paths = glob.glob(com_ocean_history)
-if matching_paths:
-    com_ocean_history = matching_paths[0]  # Assuming you want the first match
-    print(com_ocean_history)
-else:
-    print(com_ocean_history)
-    print("No matching paths found")
-    exit(1)
-del matching_paths
+plot_background = os.getenv('PLOT_BACKGROUND', 'OFF').upper() == 'ON'
+if plot_background:
+    # resolve the comout path since it may contain wild cards
+    matching_paths = glob.glob(com_ice_history)
+    if matching_paths:
+        com_ice_history = matching_paths[0]  # Assuming you want the first match
+        print(com_ice_history)
+    else:
+        print(com_ice_history)
+        print("No matching paths found")
+        exit(1)
+    del matching_paths
+    # resolve the comout path since it may contain wild cards
+    matching_paths = glob.glob(com_ocean_history)
+    if matching_paths:
+        com_ocean_history = matching_paths[0]  # Assuming you want the first match
+        print(com_ocean_history)
+    else:
+        print(com_ocean_history)
+        print("No matching paths found")
+        exit(1)
+    del matching_paths
 
 cyc = os.getenv('cyc')
 RUN = os.getenv('RUN')
@@ -74,7 +75,6 @@ HOMEgdasmv = os.getenv('HOMEgdasmv')
 # Get flags from environment variables (set in the bash driver)
 plot_ensemble_b = os.getenv('PLOT_ENSEMBLE_B', 'OFF').upper() == 'ON'
 plot_parametric_b = os.getenv('PLOT_PARAMETRIC_B', 'OFF').upper() == 'ON'
-plot_background = os.getenv('PLOT_BACKGROUND', 'OFF').upper() == 'ON'
 plot_letkf_ensemble = os.getenv('PLOT_LETKF_ENSEMBLE', 'OFF').upper() == 'ON'
 plot_increment = os.getenv('PLOT_INCREMENT', 'OFF').upper() == 'ON'
 plot_analysis = os.getenv('PLOT_ANALYSIS', 'OFF').upper() == 'ON'
@@ -112,27 +112,27 @@ if plot_analysis:
 # Ensemble B plotting configuration
 if plot_ensemble_b:
     print('Plotting ensemble B SSH diagnostics')
-    config_ens = [plotConfig(grid_file=grid_file,
+    config_ens = [plotConfig(grid_file=grid_file_bkgerr,
                              data_file=os.path.join(comout, f'{RUN}.t{cyc}z.ocn.recentering_error.nc'),
                              variables_horiz={'ave_ssh': [-1, 1]},
                              colormap='seismic',
                              vrfyout=os.path.join(vrfyout, 'vrfy', 'recentering_error')),   # recentering error
-                  plotConfig(grid_file=grid_file,
+                  plotConfig(grid_file=grid_file_bkgerr,
                              data_file=os.path.join(comout, f'{RUN}.t{cyc}z.ocn.ssh_steric_stddev.nc'),
                              variables_horiz={'ave_ssh': [0, 0.8]},
                              colormap='gist_ncar',
                              vrfyout=os.path.join(vrfyout, 'vrfy', 'bkgerr', 'ssh_steric_stddev')),  # ssh steric stddev
-                  plotConfig(grid_file=grid_file,
+                  plotConfig(grid_file=grid_file_bkgerr,
                              data_file=os.path.join(comout, f'{RUN}.t{cyc}z.ocn.ssh_unbal_stddev.nc'),
                              variables_horiz={'ave_ssh': [0, 0.8]},
                              colormap='gist_ncar',
                              vrfyout=os.path.join(vrfyout, 'vrfy', 'bkgerr', 'ssh_unbal_stddev')),   # ssh unbal stddev
-                  plotConfig(grid_file=grid_file,
+                  plotConfig(grid_file=grid_file_bkgerr,
                              data_file=os.path.join(comout, f'{RUN}.t{cyc}z.ocn.ssh_total_stddev.nc'),
                              variables_horiz={'ave_ssh': [0, 0.8]},
                              colormap='gist_ncar',
                              vrfyout=os.path.join(vrfyout, 'vrfy', 'bkgerr', 'ssh_total_stddev')),   # ssh total stddev
-                  plotConfig(grid_file=grid_file,
+                  plotConfig(grid_file=grid_file_bkgerr,
                              data_file=os.path.join(comout, f'{RUN}.t{cyc}z.ocn.steric_explained_variance.nc'),
                              variables_horiz={'ave_ssh': [0, 1]},
                              colormap='seismic',

--- a/applications/obsstats_ts/gdassoca_obsstats.py
+++ b/applications/obsstats_ts/gdassoca_obsstats.py
@@ -73,11 +73,11 @@ class ObsStats:
             # Plot RMSE, obs error, obs error + spread
             axs[0].plot(exp_data['date'], exp_data['RMSE'], marker='o', linestyle='-',
                         color=colors[exp_counter], label='RMSE ' + exp)
-            if ('EnsStd' in exp_data) and ('ObsErr' in exp_data):
-                axs[0].plot(exp_data['date'], exp_data['EnsStd'] + exp_data['ObsErr'], marker='s', linestyle='-',
+            if (exp.endswith("letkf")):
+                axs[0].plot(exp_data['date'], exp_data['EnsStd'] + exp_data['ObsErr'], marker='x', linestyle='--',
                             color=colors[exp_counter], label='EnsStd+ObsErr ' + exp)
-            if ('EnsStd' in exp_data):
-                axs[0].plot(exp_data['date'], exp_data['EnsStd'], marker='x', linestyle='-',
+            if (exp.endswith("letkf")):
+                axs[0].plot(exp_data['date'], exp_data['EnsStd'], marker='s', linestyle='-',
                             color=colors[exp_counter], label='EnsStd ' + exp)
             axs[0].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d %H'))
             axs[0].xaxis.set_major_locator(mdates.DayLocator())
@@ -139,11 +139,14 @@ if __name__ == "__main__":
     # Get all instruments/obs spaces
     for exp in args.exps:
         wc = exp + f'/*.*/??/analysis/ocean/*{inst}*.stats.csv'
-        if (args.letkf):
-            wc = exp + f'/*.*/??/analysis/ocean/letkf/diags/*{inst}*.stats.csv'
         flist = glob.glob(wc)
         for fname in flist:
             insts.append(get_inst(fname))
+        if (args.letkf):
+            wc = exp + f'/*.*/??/analysis/ocean/letkf/diags/*{inst}*.stats.csv'
+            flist = glob.glob(wc)
+            for fname in flist:
+                insts.append(get_inst(fname))
     insts = list(set(insts))
     insts.sort()
     print(insts)
@@ -154,9 +157,10 @@ if __name__ == "__main__":
         flist = []
         for exp in args.exps:
             wc = exp + f'/*.*/??/analysis/ocean/*{inst}*.stats.csv'
+            flist.append(glob.glob(wc))
             if (args.letkf):
                 wc = exp + f'/*.*/??/analysis/ocean/letkf/diags/*{inst}*.stats.csv'
-            flist.append(glob.glob(wc))
+                flist.append(glob.glob(wc))
 
         flist = sum(flist, [])
         obsStats = ObsStats()


### PR DESCRIPTION
## Description

- improves on letkf obsstats: now plotting both var and letkf on the same plot (previously only plotting letkf if `--letkf` option is specified), e.g.:
![sst_avhrr_ma_l3u_ombg_qc_Global](https://github.com/user-attachments/assets/54397b1f-5ad9-4292-a1c2-0d2473f1b27e)
- bugfix for plotting "ensemble b": needed to point to the low res grid files
- small improvement for checking existing paths: now only checking whether background paths exist when "background" plotting option is selected.

## Testing

Using this version of plotting for the plots I showed today.