### PR TITLE
Add extra EVA map_plots: OmA, hofx, ObsError, ObsTime

### DIFF
--- a/applications/cycle_diagnostics/marine_eva_post.py
+++ b/applications/cycle_diagnostics/marine_eva_post.py
@@ -5,15 +5,32 @@ import logging
 import os
 import socket
 import yaml
+import numpy as np
+from netCDF4 import Dataset
 
 # sets the cmap vmin/vmax for each variable
 # TODO: this should probably be in a yaml or something
+# ... For OmB, OmA
 vminmax = {'seaSurfaceTemperature': {'vmin': -2.0, 'vmax': 2.0},
            'seaIceFraction': {'vmin': -0.2, 'vmax': 0.2},
            'seaSurfaceSalinity': {'vmin': -0.2, 'vmax': 0.2},  # TODO: this should be changed
            'absoluteDynamicTopography': {'vmin': -0.2, 'vmax': 0.2},
            'waterTemperature': {'vmin': -2.0, 'vmax': 2.0},
            'salinity': {'vmin': -0.2, 'vmax': 0.2}}
+# ... For hofx
+vminmax_hofx = {'seaSurfaceTemperature': {'vmin': -5.0, 'vmax': 30.0},
+                'seaIceFraction': {'vmin': 0.0, 'vmax': 1.0},
+                'seaSurfaceSalinity': {'vmin': 0.0, 'vmax': 50.0},  # TODO: this should be changed
+                'absoluteDynamicTopography': {'vmin': 0.0, 'vmax': 1.0},
+                'waterTemperature': {'vmin': -5.0, 'vmax': 30.0},
+                'salinity': {'vmin': 0.0, 'vmax': 50.0}}
+# ... For obs errors
+vminmax_error = {'seaSurfaceTemperature': {'vmin': 0.0, 'vmax': 1.0},
+                 'seaIceFraction': {'vmin': 0.0, 'vmax': 0.2},
+                 'seaSurfaceSalinity': {'vmin': 0.0, 'vmax': 1.0},  # TODO: this should be changed
+                 'absoluteDynamicTopography': {'vmin': 0.0, 'vmax': 1.0},
+                 'waterTemperature': {'vmin': 0.0, 'vmax': 1.0},
+                 'salinity': {'vmin': 0.0, 'vmax': 1.0}}
 
 
 def marine_eva_post(inputyaml, outputdir, diagdir):
@@ -26,20 +43,69 @@ def marine_eva_post(inputyaml, outputdir, diagdir):
         logging.error(f'Error occurred when attempting to load: {inputyaml}, error: {e}')
         return
     for dataset in input_yaml_dict['datasets']:
+        # Get filenames
         newfilenames = []
         for filename in dataset['filenames']:
             newfilename = os.path.join(diagdir, os.path.basename(filename))
             newfilenames.append(newfilename)
         dataset['filenames'] = newfilenames
+        # Get group names of fields
+        newgroupnames = []
+        for groupname in dataset['groups']:
+            gnames = groupname['name']
+            newgroupnames.append(gnames)
+
+    # Set vmin/vmax based on yaml and var_min/var_max
     for graphic in input_yaml_dict['graphics']['figure_list']:
-        # this assumes that there is only one variable, or that the
+        # This assumes that there is only one variable, or that the
         # variables are all the same
         variable = graphic['batch figure']['variables'][0]
+
         for plot in graphic['plots']:
             for layer in plot['layers']:
                 if layer['type'] == 'MapScatter':
-                    layer['vmin'] = vminmax[variable]['vmin']
-                    layer['vmax'] = vminmax[variable]['vmax']
+                    # Initialize some variables
+                    var_min = -999
+                    var_max = -999
+                    dynopt = graphic['dynamic options']
+                    dynstr = ""
+                    # This loop is only used for the ObsTime map plot: to find var_min/var_max of "dateTime"
+                    for tdyn in dynopt:
+                        sdyn = str(tdyn)
+                        dyn = ""
+                        # String together "dynamic options" line from yaml
+                        for ss in sdyn:
+                            dyn += ss
+                        # Loop through group names of fields to find "metadata" (for "dateTime" plot)
+                        for tname in newgroupnames:
+                            invar = ""
+                            if str(tname).lower().find('metadata') != -1 and str(dyn).lower().find('obstime') != -1:
+                                invar = "dateTime"
+                                dynstr = str(tname)
+                                # Open diag file to get "dateTime" variable
+                                ds = Dataset(dataset['filenames'][0], mode="r")
+                                vardata = ds.groups[tname].variables[invar]
+                                # Find min/max dateTime (in seconds from epoch)
+                                tmin = np.nanmin(vardata)
+                                tmax = np.nanmax(vardata)
+                                var_min = int(np.round(tmin, decimals=-1))
+                                var_max = int(np.round(tmax, decimals=-1))
+                                # Close diag file
+                                ds.close()
+                                break
+                    # Set min/max for map plot
+                    if dynstr.lower().find('omb') != -1 or dynstr.lower().find('oma') != -1:
+                        layer['vmin'] = vminmax[variable]['vmin']
+                        layer['vmax'] = vminmax[variable]['vmax']
+                    elif dynstr.lower().find('hofx') != -1:
+                        layer['vmin'] = vminmax_hofx[variable]['vmin']
+                        layer['vmax'] = vminmax_hofx[variable]['vmax']
+                    elif dynstr.lower().find('error') != -1:
+                        layer['vmin'] = vminmax_error[variable]['vmin']
+                        layer['vmax'] = vminmax_error[variable]['vmax']
+                    elif dynstr.lower().find('metadata') != -1:
+                        layer['vmin'] = var_min
+                        layer['vmax'] = var_max
 
     # first, let us prepend some comments that tell someone this output YAML was generated
     now = datetime.datetime.now()

--- a/applications/cycle_diagnostics/marine_eva_post.py
+++ b/applications/cycle_diagnostics/marine_eva_post.py
@@ -27,10 +27,10 @@ vminmax_hofx = {'seaSurfaceTemperature': {'vmin': -5.0, 'vmax': 30.0},
 # ... For obs errors
 vminmax_error = {'seaSurfaceTemperature': {'vmin': 0.0, 'vmax': 1.0},
                  'seaIceFraction': {'vmin': 0.0, 'vmax': 0.2},
-                 'seaSurfaceSalinity': {'vmin': 0.0, 'vmax': 1.0},  # TODO: this should be changed
+                 'seaSurfaceSalinity': {'vmin': 0.0, 'vmax': 10.0},  # TODO: this should be changed
                  'absoluteDynamicTopography': {'vmin': 0.0, 'vmax': 1.0},
                  'waterTemperature': {'vmin': 0.0, 'vmax': 1.0},
-                 'salinity': {'vmin': 0.0, 'vmax': 1.0}}
+                 'salinity': {'vmin': 0.0, 'vmax': 10.0}}
 
 
 def marine_eva_post(inputyaml, outputdir, diagdir):
@@ -49,63 +49,47 @@ def marine_eva_post(inputyaml, outputdir, diagdir):
             newfilename = os.path.join(diagdir, os.path.basename(filename))
             newfilenames.append(newfilename)
         dataset['filenames'] = newfilenames
-        # Get group names of fields
-        newgroupnames = []
-        for groupname in dataset['groups']:
-            gnames = groupname['name']
-            newgroupnames.append(gnames)
 
     # Set vmin/vmax based on yaml and var_min/var_max
     for graphic in input_yaml_dict['graphics']['figure_list']:
         # This assumes that there is only one variable, or that the
         # variables are all the same
         variable = graphic['batch figure']['variables'][0]
-
         for plot in graphic['plots']:
             for layer in plot['layers']:
+                # Find plot type
+                plotdata = layer
+                typestr = str(plotdata)
                 if layer['type'] == 'MapScatter':
-                    # Initialize some variables
-                    var_min = -999
-                    var_max = -999
-                    dynopt = graphic['dynamic options']
-                    dynstr = ""
-                    # This loop is only used for the ObsTime map plot: to find var_min/var_max of "dateTime"
-                    for tdyn in dynopt:
-                        sdyn = str(tdyn)
-                        dyn = ""
-                        # String together "dynamic options" line from yaml
-                        for ss in sdyn:
-                            dyn += ss
-                        # Loop through group names of fields to find "metadata" (for "dateTime" plot)
-                        for tname in newgroupnames:
-                            invar = ""
-                            if str(tname).lower().find('metadata') != -1 and str(dyn).lower().find('obstime') != -1:
-                                invar = "dateTime"
-                                dynstr = str(tname)
-                                # Open diag file to get "dateTime" variable
-                                ds = Dataset(dataset['filenames'][0], mode="r")
-                                vardata = ds.groups[tname].variables[invar]
-                                # Find min/max dateTime (in seconds from epoch)
-                                tmin = np.nanmin(vardata)
-                                tmax = np.nanmax(vardata)
-                                var_min = int(np.round(tmin, decimals=-1))
-                                var_max = int(np.round(tmax, decimals=-1))
-                                # Close diag file
-                                ds.close()
-                                break
+                    # Find min/max obs time if plot is of "metadata"/"dateTime"
+                    if str(typestr).lower().find('obstime') != -1:
+                        # Open diag file to get "dateTime" variable
+                        ds = Dataset(dataset['filenames'][0], mode="r")
+                        vardata = ds.groups["MetaData"].variables["dateTime"]
+                        # Find min/max dateTime (in seconds from epoch)
+                        tmin = np.nanmin(vardata)
+                        tmax = np.nanmax(vardata)
+                        var_min = int(np.round(tmin, decimals=-1))
+                        var_max = int(np.round(tmax, decimals=-1))
+                        # Close diag file
+                        ds.close()
+                        break
                     # Set min/max for map plot
-                    if dynstr.lower().find('omb') != -1 or dynstr.lower().find('oma') != -1:
+                    if typestr.lower().find('omb') != -1 or typestr.lower().find('oma') != -1:
                         layer['vmin'] = vminmax[variable]['vmin']
                         layer['vmax'] = vminmax[variable]['vmax']
-                    elif dynstr.lower().find('hofx') != -1:
+                    elif typestr.lower().find('hofx') != -1:
                         layer['vmin'] = vminmax_hofx[variable]['vmin']
                         layer['vmax'] = vminmax_hofx[variable]['vmax']
-                    elif dynstr.lower().find('error') != -1:
+                    elif typestr.lower().find('error') != -1:
                         layer['vmin'] = vminmax_error[variable]['vmin']
                         layer['vmax'] = vminmax_error[variable]['vmax']
-                    elif dynstr.lower().find('metadata') != -1:
+                    elif typestr.lower().find('obstime') != -1:
                         layer['vmin'] = var_min
                         layer['vmax'] = var_max
+                    else:
+                        layer['vmin'] = vminmax[variable]['vmin']
+                        layer['vmax'] = vminmax[variable]['vmax']
 
     # first, let us prepend some comments that tell someone this output YAML was generated
     now = datetime.datetime.now()

--- a/configs/marine_gdas_plots.yaml
+++ b/configs/marine_gdas_plots.yaml
@@ -43,7 +43,7 @@ transforms:
     for:
       variable: *variables
 
-  # Generate oma that passed QC for JEDI
+  # Generate hofx that passed QC for JEDI
   - transform: accept where
     new name: experiment::hofxQC::${variable}
     starting field: experiment::hofx0::${variable}
@@ -52,6 +52,23 @@ transforms:
     for:
       variable: *variables
 
+  # Generate obserror for obs that passed QC for JEDI
+  - transform: accept where
+    new name: experiment::ObsErrorQC::${variable}
+    starting field: experiment::ObsError::${variable}
+    where:
+      - experiment::EffectiveQC0::${variable} == 0
+    for:
+      variable: *variables
+
+  # Generate obs timing for obs that passed QC for JEDI
+  - transform: accept where
+    new name: experiment::ObsTimeQC::${variable}
+    starting field: experiment::MetaData::dateTime
+    where:
+      - experiment::EffectiveQC0::${variable} == 0
+    for:
+      variable: *variables
 
 
 
@@ -62,9 +79,10 @@ graphics:
   figure_list:
 
   # ---------- Map Plots ----------
-  # Map plot of OmBQC
+  # Map plots
   # --------
 
+  # Map of OmB
   - batch figure:
       variables: *variables
       @CHANNELSKEY@
@@ -99,6 +117,154 @@ graphics:
           colorbar: true
           # below may need to be edited/removed
           cmap: 'seismic'
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  # Map of OmA
+  - batch figure:
+      variables: *variables
+      @CHANNELSKEY@
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::OmAQC::${variable}
+    figure:
+      layout: [1,1]
+      figure size: [20,10]
+      title: 'OmA post QC | @NAME@ @CYCLE@ | ${variable_title}'
+      output name: map_plots/@NAME@/${variable}/@CHANNELVAR@/@NAME@_${variable}@CHANNELVAR@OmAQC.png
+      tight_layout: true
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_grid:
+        add_colorbar:
+           label: '${variable}'
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::OmAQC::${variable}
+            @CHANNELKEY@
+          markersize: 0.01
+          label: '$(variable)'
+          colorbar: true
+          cmap: 'seismic'
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  # Map of hofx
+  - batch figure:
+      variables: *variables
+      @CHANNELSKEY@
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::hofxQC::${variable}
+    figure:
+      layout: [1,1]
+      figure size: [20,10]
+      title: 'hofx post QC | @NAME@ @CYCLE@ | ${variable_title}'
+      output name: map_plots/@NAME@/${variable}/@CHANNELVAR@/@NAME@_${variable}@CHANNELVAR@hofxQC.png
+      tight_layout: true
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_grid:
+        add_colorbar:
+           label: '${variable}'
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::hofxQC::${variable}
+            @CHANNELKEY@
+          markersize: 0.01
+          label: '$(variable)'
+          colorbar: true
+          cmap: 'nipy_spectral'
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  # Map of observation error
+  - batch figure:
+      variables: *variables
+      @CHANNELSKEY@
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::ObsErrorQC::${variable}
+    figure:
+      layout: [1,1]
+      figure size: [20,10]
+      title: 'ObsError where Obs post QC | @NAME@ @CYCLE@ | ${variable_title}'
+      output name: map_plots/@NAME@/${variable}/@CHANNELVAR@/@NAME@_${variable}@CHANNELVAR@ObsErrorQC.png
+      tight_layout: true
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_grid:
+        add_colorbar:
+           label: '${variable} Error'
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ObsErrorQC::${variable}
+            @CHANNELKEY@
+          markersize: 0.01
+          label: '$(variable)'
+          colorbar: true
+          cmap: 'nipy_spectral'
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  # Map of observation times
+  - batch figure:
+      variables: *variables
+      @CHANNELSKEY@
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::ObsTimeQC::${variable}
+    figure:
+      layout: [1,1]
+      figure size: [20,10]
+      title: 'ObsTime post QC | @NAME@ @CYCLE@ | ${variable_title}'
+      output name: map_plots/@NAME@/${variable}/@CHANNELVAR@/@NAME@_${variable}@CHANNELVAR@ObsTimeQC.png
+      tight_layout: true
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_grid:
+        add_colorbar:
+           label: 'Time of Observation (s)'
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ObsTimeQC::${variable}
+            @CHANNELKEY@
+          markersize: 0.01
+          label: '$(variable)'
+          colorbar: true
+          cmap: 'nipy_spectral'
           vmin: ${dynamic_vmin}
           vmax: ${dynamic_vmax}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ kiwisolver==1.4.7
 MarkupSafe==3.0.2
 matplotlib
 mccabe==0.7.0
+netCDF4
 numpy
 packaging==24.2
 panda==0.3.1


### PR DESCRIPTION
## Description

This PR is an update to PR#<512>: It now passes all checks.

This PR adds the capability to plot additional diag maps in run_vrfy using EVA:

-hofx
-OmA
-Observation Error
-Observation Time

### Issue(s) addressed

Fixes #<512>

## Testing

This tool has been successfully tested on HERA.
